### PR TITLE
Stream update command output

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,39 @@ via `d8x setup broker-deploy`
 <details>
   <summary>How do I update the swarm server software images to a new version?</summary>
 
+**Via CLI**
+
+You can update services running in docker swarm and broker server by using the
+`d8x update` command. Command `update` will walk you through the update process.
+You will be prompted to select which services you want to update in the swarm
+cluster and then in the broker server.
+
+For swarm services, you will need to  provide a fully qualified url of docker
+image for the service to update to.
+
+Example:
+
+Let's say our main `api` service is running as
+`ghcr.io/d8-x/d8x-trader-main:main` image in our swarm setup. Now, if you want
+to update service `api` to the latest version of
+`ghcr.io/d8-x/d8x-trader-main:main` (`main` tag), simply updating to use
+`ghcr.io/d8-x/d8x-trader-main:main` image will not work. This is because swarm
+nodes will see that this image with main tag is already downloaded and even
+though there is a newer version of `main` image in container registry, it will
+not pull it (because the tag is the same). In order to force the upate of a
+specific tag that is already available and running in swarm, you have to specify
+the sha hash of the image. For example
+`ghcr.io/d8-x/d8x-trader-main:main@sha256:2ce51e825a559029f47e73a73531d8a0b10191c6bc16950649036edf20ea8c35`
+
+For broker server services, update will attempt to update services to the latest
+version available. This is because broker services are running in docker compose
+and the `update` command simply removes old containers and images and pulls new
+ones.
+
+
+
+**Manually**
+
 You login to the server where your software resides (e.g., the broker-server, or the
 swarm-manager for which you can get the ip with `d8x ip manager`).
 

--- a/internal/actions/svc_update.go
+++ b/internal/actions/svc_update.go
@@ -302,7 +302,7 @@ func (c *Container) updateBrokerServerServices(selectedSwarmServicesToUpdate []s
 			}
 		}
 
-		out, err := sshConn.ExecCommand(
+		if err := sshConn.ExecCommandPiped(
 			fmt.Sprintf(
 				`cd %s && docker compose down --rmi all %[2]s && BROKER_FEE_TBPS=%s REDIS_PW=%s docker compose up %[2]s -d`,
 				brokerDir,
@@ -311,10 +311,7 @@ func (c *Container) updateBrokerServerServices(selectedSwarmServicesToUpdate []s
 				feeTBPS,
 				redisPassword,
 			),
-		)
-
-		if err != nil {
-			fmt.Println(string(out))
+		); err != nil {
 			return err
 		} else {
 			fmt.Println(styles.SuccessText.Render(fmt.Sprintf("Broker-server service %s updated to latest version", svcToUpdate)))

--- a/internal/actions/svc_update.go
+++ b/internal/actions/svc_update.go
@@ -168,7 +168,6 @@ func (c *Container) updateSwarmServices(ctx *cli.Context, selectedSwarmServicesT
 			err := sshConn.ExecCommandPiped(
 				fmt.Sprintf(`docker service update --image %s %s`, imgToUse, svcStackName),
 			)
-			// fmt.Println(string(out))
 			if err != nil {
 				fmt.Println(
 					styles.ErrorText.Render(

--- a/internal/actions/svc_update.go
+++ b/internal/actions/svc_update.go
@@ -99,9 +99,15 @@ func (c *Container) updateSwarmServices(ctx *cli.Context, selectedSwarmServicesT
 			continue
 		}
 
-		fmt.Printf("Available tags: %s\n", strings.Join(tags, ", "))
+		fmt.Printf("Available tags: %s\n\n", strings.Join(tags, ", "))
 
-		fmt.Printf("Provide a full path to image with tag (or optionally sha256 hash) to update to:\n")
+		fmt.Printf("Provide a full path to image with tag (or optionally sha256 hash) to update to\n")
+		info := "When providing a specific sha version, follow the following format:\nghcr.io/d8-x/<SERVICE>@sha256:<SHA256_HASH>\n"
+		fmt.Println(styles.GrayText.Render(info))
+		info = "When providing a tag only, follow the following format:\nghcr.io/d8-x/<SERVICE>:<TAG>\n"
+		fmt.Println(styles.GrayText.Render(info))
+
+		fmt.Println("Enter image to update to:")
 		imgToUse, err := c.TUI.NewInput(
 			components.TextInputOptValue(img),
 			components.TextInputOptPlaceholder("ghcr.io/d8-x/image@sha256:hash"),
@@ -118,10 +124,9 @@ func (c *Container) updateSwarmServices(ctx *cli.Context, selectedSwarmServicesT
 
 			// Remove existing referral service
 			fmt.Println("Scaling down referral service")
-			if out, err := sshConn.ExecCommand(
+			if err := sshConn.ExecCommandPiped(
 				fmt.Sprintf("docker service scale %s_%s=0", dockerStackName, svcToUpdate),
 			); err != nil {
-				fmt.Println(string(out))
 				fmt.Println(styles.ErrorText.Render(
 					fmt.Sprintf("removing referral service: %v\n", err),
 				))
@@ -160,10 +165,10 @@ func (c *Container) updateSwarmServices(ctx *cli.Context, selectedSwarmServicesT
 		t := time.NewTimer(time.Minute * 2)
 		done := make(chan struct{})
 		go func() {
-			out, err := sshConn.ExecCommand(
+			err := sshConn.ExecCommandPiped(
 				fmt.Sprintf(`docker service update --image %s %s`, imgToUse, svcStackName),
 			)
-			fmt.Println(string(out))
+			// fmt.Println(string(out))
 			if err != nil {
 				fmt.Println(
 					styles.ErrorText.Render(
@@ -180,10 +185,9 @@ func (c *Container) updateSwarmServices(ctx *cli.Context, selectedSwarmServicesT
 
 			// Scale back the referral service
 			if svcToUpdate == "referral" {
-				if out, err := sshConn.ExecCommand(
+				if err := sshConn.ExecCommandPiped(
 					fmt.Sprintf("docker service scale %s_%s=1", dockerStackName, svcToUpdate),
 				); err != nil {
-					fmt.Println(string(out))
 					fmt.Println(styles.ErrorText.Render(
 						fmt.Sprintf("scaling referral service: %v\n", err),
 					))

--- a/internal/conn/ssh.go
+++ b/internal/conn/ssh.go
@@ -2,6 +2,7 @@ package conn
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"time"
 
@@ -113,6 +114,7 @@ func (conn *sshConnection) ExecCommandPiped(cmd string) error {
 	if err != nil {
 		return err
 	}
+	defer s.Close()
 
 	if err := s.RequestPty("xterm", 80, 80,
 		ssh.TerminalModes{
@@ -124,18 +126,19 @@ func (conn *sshConnection) ExecCommandPiped(cmd string) error {
 		return err
 	}
 
-	s.Stdin = os.Stdin
-	s.Stdout = os.Stdout
-	s.Stderr = os.Stderr
-	if err := s.Shell(); err != nil {
-		return err
+	out, err := s.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("retrieving remote stdout: %w", err)
 	}
 
-	if _, err := os.Stdin.Read([]byte(cmd)); err != nil {
-		return err
-	}
+	go func() {
+		for {
+			io.Copy(os.Stdout, out)
+		}
+	}()
 
-	return s.Close()
+	return s.Run(cmd)
+
 }
 
 func (conn *sshConnection) CopyFilesOverSftp(srcDst ...SftpCopySrcDest) error {

--- a/internal/conn/ssh.go
+++ b/internal/conn/ssh.go
@@ -133,7 +133,10 @@ func (conn *sshConnection) ExecCommandPiped(cmd string) error {
 
 	go func() {
 		for {
-			io.Copy(os.Stdout, out)
+			n, err := io.Copy(os.Stdout, out)
+			if err != nil || n == 0 {
+				return
+			}
 		}
 	}()
 

--- a/internal/styles/text.go
+++ b/internal/styles/text.go
@@ -30,6 +30,8 @@ var (
 			Italic(true)
 
 	CommandTitleText = ItalicText.Copy().Bold(true)
+
+	GrayText = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
 )
 
 var (


### PR DESCRIPTION
**Change Description:**

This PR adds functionality to pipe remote command output to current terminal.
Changed service update command execution funcs to use output streaming. We
now use output streaming for some commands which would usually take longer or
could potentially "hang". This way the user can see whether the execution of
update should be aborted.

**Expected Outcomes:**

Longer running `docker service update` and `docker compose down/up` commands
stream the output to the current terminal when performing service update.

**Impact Analysis:**

Update functionality.

**Test Cases:**

Check output, check image hashes after update


**Test Results:**  

Service update, compose up commands stream the output, it is now more clear
what is happening under the hood if it takes more time to execute these
commands.

Before update:
 - main api: ghcr.io/d8-x/d8x-trader-main:main@sha256:96551b3b49b3ede2540bb00caf5be8fdcca0512a00ee97646e26802419ed1a06
 - referral: ghcr.io/d8-x/d8x-referral-system:main@sha256:8921056bb79ea442a6c6f7a3469a117743bc6901c0ed620a139f516cc5872d16
 - broker (broker svc): ghcr.io/d8-x/d8x-broker-server@sha256:2e77fbf953ca98d4f1c1eec571ada368833205c13665b7a6124020f5c96bb328

Update to:
- main api: ghcr.io/d8-x/d8x-trader-main:dev
- referral: ghcr.io/d8-x/d8x-referral-system:dev
- broker: latest

After update:
- main api: ghcr.io/d8-x/d8x-trader-main:main@sha256:96551b3b49b3ede2540bb00caf5be8fdcca0512a00ee97646e26802419ed1a06
- referral: ghcr.io/d8-x/d8x-referral-system:dev@sha256:838ae6e314fc062cbc62d80cce89bb25df9b65c51dd9389b87cf2ef090cb8d0c
- broker (broker svc): ghcr.io/d8-x/d8x-broker-server@sha256:2e77fbf953ca98d4f1c1eec571ada368833205c13665b7a6124020f5c96bb328
