### PR TITLE
Better error message for absent broker-server

### DIFF
--- a/internal/actions/broker.go
+++ b/internal/actions/broker.go
@@ -179,6 +179,9 @@ func (c *Container) BrokerServerNginxCertbotSetup(ctx *cli.Context) error {
 
 	brokerIpAddr, err := c.HostsCfg.GetBrokerPublicIp()
 	if err != nil {
+		fmt.Println(
+			styles.ErrorText.Render("Broker server ip address was not found. Did you provision broker server?"),
+		)
 		return err
 	}
 

--- a/internal/actions/broker.go
+++ b/internal/actions/broker.go
@@ -29,6 +29,18 @@ func (c *Container) BrokerDeploy(ctx *cli.Context) error {
 		return err
 	}
 
+	bsd := brokerServerDeployment{}
+
+	// Check for broker ip address
+	brokerIpAddr, err := c.HostsCfg.GetBrokerPublicIp()
+	if err != nil {
+		fmt.Println(
+			styles.ErrorText.Render("Broker server ip address was not found. Did you provision broker server?"),
+		)
+		return err
+	}
+	bsd.brokerServerIpAddr = brokerIpAddr
+
 	// Dest filenames for copying from embed. TODO - centralize this via flags
 	var (
 		chainConfig   = "./broker-server/chainConfig.json"
@@ -68,14 +80,6 @@ func (c *Container) BrokerDeploy(ctx *cli.Context) error {
 	fmt.Println(
 		styles.SuccessText.Render("REDIS Password for broker-server was stored in " + BROKER_SERVER_REDIS_PWD_FILE + " file"),
 	)
-
-	bsd := brokerServerDeployment{}
-
-	brokerIpAddr, err := c.HostsCfg.GetBrokerPublicIp()
-	if err != nil {
-		return err
-	}
-	bsd.brokerServerIpAddr = brokerIpAddr
 
 	// Collect required information
 	fmt.Println("Enter your broker private key:")

--- a/internal/files/hosts.go
+++ b/internal/files/hosts.go
@@ -93,6 +93,7 @@ func LoadHostsFileFromFS(file string) (*HostsFile, error) {
 	return &HostsFile{
 		lines:    lines,
 		numLines: len(lines),
+		fileName: file,
 	}, nil
 }
 
@@ -100,6 +101,7 @@ func LoadHostsFileFromFS(file string) (*HostsFile, error) {
 type HostsFile struct {
 	lines    []string
 	numLines int
+	fileName string
 }
 
 // GetBrokerPublicIp gets the first broker server entry from hosts.cfg and
@@ -154,7 +156,7 @@ func (h *HostsFile) FindFirstIp(of string) (string, error) {
 			}
 		}
 	}
-	return "", nil
+	return "", fmt.Errorf("could not find line %s in hosts.cfg file", of)
 }
 
 // FindPrivateIps returns the private ips of either nodeType=manager


### PR DESCRIPTION

**Change Description:**

This PR introduces more user friendly error message when broker setup related
actions are performed but broker-server is not provisioned

**Expected Outcomes:**

See description 

**Impact Analysis:**

None

**Test Cases:**

Setup without broker server. Attempt to ssh into broker server via `ssh
broker`. Attempt to perform any of broker setup actions `broker-deploy` or
`broker-nginx`

**Test Results:**  

When no [broker] entry is present in hosts.cfg.


`d8x ssh broker`
```bash
2023/11/16 11:57:35 broker ip was not found in hosts file: could not find line [broker] in hosts.cfg file
exit status 1
```

`d8x setup broker-deploy` or  `broker-nginx`

```bash
Broker server ip address was not found. Did you provision broker server?
2023/11/16 11:59:32 broker ip was not found in hosts file: could not find line [broker] in hosts.cfg file
exit status 1
```
