### PR TITLE
allow creating multiple deployments

### DIFF
--- a/internal/actions/provision.go
+++ b/internal/actions/provision.go
@@ -44,16 +44,18 @@ func (c *Container) Provision(ctx *cli.Context) error {
 		return fmt.Errorf("collecting server provider details: %w", err)
 	}
 
-	// Terraform apply for selected server provider
-	tfCmd, err := providerConfigurer.BuildTerraformCMD(c)
-	if err != nil {
-		return err
-	}
-
-	// Exec terraform init
+	// Exec terraform init before we create provider cmd, so in case provider
+	// configurer perfroms any checks before building cmd - we already have tf
+	// init in place.
 	tfInit := exec.Command("terraform", "init")
 	connectCMDToCurrentTerm(tfInit)
 	if err := tfInit.Run(); err != nil {
+		return err
+	}
+
+	// Terraform apply for selected server provider
+	tfCmd, err := providerConfigurer.BuildTerraformCMD(c)
+	if err != nil {
 		return err
 	}
 

--- a/internal/actions/provision.go
+++ b/internal/actions/provision.go
@@ -63,6 +63,7 @@ func (c *Container) Provision(ctx *cli.Context) error {
 		connectCMDToCurrentTerm(tfCmd)
 		err := tfCmd.Run()
 		if err != nil {
+			fmt.Println(styles.ErrorText.Render("Terraform apply failed, please check the output above for more details.\nPossible issues:\n\tDuplicate server label\n\tIncorrect AWS credentials\n\tSelected region was used first time"))
 			return err
 		}
 	}

--- a/internal/actions/provision_aws.go
+++ b/internal/actions/provision_aws.go
@@ -160,7 +160,7 @@ func (c *Container) createAWSServerConfigurer() (ServerProviderConfigurer, error
 	}
 	awsCfg.RDSInstanceClass = dbClass
 
-	fmt.Println("Enter server tag prefix (must be  between deployments): ")
+	fmt.Println("Enter server tag prefix (must be unique between deployments): ")
 	labelPrefix, err := c.TUI.NewInput(
 		components.TextInputOptValue(awsServerLabelPrefix),
 		components.TextInputOptPlaceholder("my-cluster"),

--- a/internal/actions/provision_aws.go
+++ b/internal/actions/provision_aws.go
@@ -34,10 +34,10 @@ func (a *awsConfigurer) BuildTerraformCMD(c *Container) (*exec.Cmd, error) {
 	if err := c.EmbedCopier.CopyMultiToDest(
 		configs.EmbededConfigs,
 		"./aws.tf",
-
 		"embedded/trader-backend/tf-aws/main.tf",
 		"embedded/trader-backend/tf-aws/routes.tf",
 		"embedded/trader-backend/tf-aws/sg.tf",
+		"embedded/trader-backend/tf-aws/pg.tf",
 		"embedded/trader-backend/tf-aws/vars.tf",
 		"embedded/trader-backend/tf-aws/output.tf",
 	); err != nil {
@@ -107,11 +107,15 @@ func (c *Container) createAWSServerConfigurer() (ServerProviderConfigurer, error
 	awsKey := ""
 	awsSecret := ""
 	awsRDSInstanceClass := "db.t4g.small"
+	awsServerLabelPrefix := "d8x-cluster"
 	if cfg.AWSConfig != nil {
 		awsKey = cfg.AWSConfig.AccesKey
 		awsSecret = cfg.AWSConfig.SecretKey
 		if cfg.AWSConfig.RDSInstanceClass != "" {
 			awsRDSInstanceClass = cfg.AWSConfig.RDSInstanceClass
+		}
+		if cfg.AWSConfig.LabelPrefix != "" {
+			awsServerLabelPrefix = cfg.AWSConfig.LabelPrefix
 		}
 	}
 
@@ -156,9 +160,9 @@ func (c *Container) createAWSServerConfigurer() (ServerProviderConfigurer, error
 	}
 	awsCfg.RDSInstanceClass = dbClass
 
-	fmt.Println("Enter server tag prefix: ")
+	fmt.Println("Enter server tag prefix (must be  between deployments): ")
 	labelPrefix, err := c.TUI.NewInput(
-		components.TextInputOptValue("d8x-cluster"),
+		components.TextInputOptValue(awsServerLabelPrefix),
 		components.TextInputOptPlaceholder("my-cluster"),
 	)
 	if err != nil {
@@ -253,6 +257,7 @@ func (a *awsConfigurer) createRDSDatabases(c *Container, historyDbName, referral
 	}
 
 	pgConn, err := pgx.ConnectConfig(context.Background(), pgCnfg)
+
 	if err != nil {
 		return fmt.Errorf("connecting to postgres instance: %w", err)
 	}

--- a/internal/configs/embedded/trader-backend/tf-aws/main.tf
+++ b/internal/configs/embedded/trader-backend/tf-aws/main.tf
@@ -7,10 +7,6 @@ terraform {
   }
 }
 
-# module "pg_instance_check" {
-#   source = "./pg_check"
-# }
-
 provider "aws" {
   region     = var.region
   access_key = var.aws_access_key
@@ -110,17 +106,6 @@ resource "aws_internet_gateway" "d8x_igw" {
     Name = "d8x-cluster-igw"
   }
 }
-
-# resource "aws_eip" "manager_public_ip" {
-#   tags = {
-#     Name = "d8x-cluster-manager-public-ip"
-#   }
-# }
-
-# resource "aws_eip_association" "eip_assoc" {
-#   instance_id   = aws_instance.manager.primary_network_interface_id
-#   allocation_id = aws_eip.manager_public_ip.id
-# }
 
 resource "aws_instance" "manager" {
   ami           = data.aws_ami.ubuntu.id

--- a/internal/configs/embedded/trader-backend/tf-aws/main.tf
+++ b/internal/configs/embedded/trader-backend/tf-aws/main.tf
@@ -7,6 +7,10 @@ terraform {
   }
 }
 
+# module "pg_instance_check" {
+#   source = "./pg_check"
+# }
+
 provider "aws" {
   region     = var.region
   access_key = var.aws_access_key
@@ -15,7 +19,7 @@ provider "aws" {
 
 // Create d8x cluster keypair
 resource "aws_key_pair" "d8x_cluster_ssh_key" {
-  key_name   = "d8x-cluster-ssh-key"
+  key_name   = format("%s-%s", var.server_label_prefix, "cluster-ssh-key")
   public_key = var.authorized_key
 }
 
@@ -105,52 +109,6 @@ resource "aws_internet_gateway" "d8x_igw" {
   tags = {
     Name = "d8x-cluster-igw"
   }
-}
-
-# Provision postgres on RDS
-resource "aws_db_subnet_group" "pg_subnet" {
-  name       = "d8x-cluster-postgres-subnet"
-  subnet_ids = [aws_subnet.workers_subnet.id, aws_subnet.private_subnet_2.id]
-  tags = {
-    Name = "private subnet association"
-  }
-}
-
-resource "random_password" "db_password" {
-  length  = 28
-  special = false
-}
-
-resource "aws_db_instance" "pg" {
-  identifier             = "d8x-cluster-pg"
-  instance_class         = var.db_instance_class
-  allocated_storage      = 5
-  engine                 = "postgres"
-  engine_version         = "15.2"
-  username               = "d8xtrader"
-  password               = random_password.db_password.result
-  vpc_security_group_ids = [aws_security_group.db_access.id]
-  db_subnet_group_name   = aws_db_subnet_group.pg_subnet.name
-  # vpc_security_group_ids = [aws_security_group.rds.id]
-  # parameter_group_name = aws_db_parameter_group.education.name
-  publicly_accessible   = false
-  skip_final_snapshot   = true
-  max_allocated_storage = 50
-}
-
-variable "pg_details" {
-  default = <<EOF
-host: %s
-user: %s
-port: %s
-password: %s
-  EOF
-}
-
-resource "local_file" "rds_db_password" {
-  depends_on = [aws_db_instance.pg]
-  content    = format(var.pg_details, aws_db_instance.pg.address, aws_db_instance.pg.username, aws_db_instance.pg.port, random_password.db_password.result)
-  filename   = var.rds_creds_filepath
 }
 
 # resource "aws_eip" "manager_public_ip" {

--- a/internal/configs/embedded/trader-backend/tf-aws/pg.tf
+++ b/internal/configs/embedded/trader-backend/tf-aws/pg.tf
@@ -1,0 +1,73 @@
+
+
+# # Provision postgres on RDS
+resource "aws_db_subnet_group" "pg_subnet" {
+  name       = format("%s-%s", var.server_label_prefix, "postgres-subnet")
+  subnet_ids = [aws_subnet.workers_subnet.id, aws_subnet.private_subnet_2.id]
+  tags = {
+    Name = "private subnet association"
+  }
+}
+
+resource "random_password" "db_password" {
+  length  = 28
+  special = false
+}
+
+resource "aws_db_instance" "pg" {
+  identifier             = format("%s-%s", var.server_label_prefix, "pg")
+  instance_class         = var.db_instance_class
+  allocated_storage      = 5
+  engine                 = "postgres"
+  engine_version         = "15.2"
+  username               = "d8xtrader"
+  password               = random_password.db_password.result
+  vpc_security_group_ids = [aws_security_group.db_access.id]
+  db_subnet_group_name   = aws_db_subnet_group.pg_subnet.name
+  # vpc_security_group_ids = [aws_security_group.rds.id]
+  # parameter_group_name = aws_db_parameter_group.education.name
+  publicly_accessible   = false
+  skip_final_snapshot   = true
+  max_allocated_storage = 50
+}
+
+variable "pg_details" {
+  default = <<EOF
+host: %s
+user: %s
+port: %s
+password: %s
+  EOF
+}
+
+resource "local_file" "rds_db_password" {
+  depends_on = [aws_db_instance.pg]
+  content    = format(var.pg_details, aws_db_instance.pg.address, aws_db_instance.pg.username, aws_db_instance.pg.port, random_password.db_password.result)
+  filename   = var.rds_creds_filepath
+}
+
+
+// Enable accessing RDS instance from private subnets
+resource "aws_security_group" "db_access" {
+  name_prefix = "d8x-cluster-posgtres-access-sg"
+  vpc_id      = aws_vpc.d8x_cluster_vpc.id
+
+  tags = {
+    Name = "d8x-cluster-posgtres-access-sg"
+  }
+
+  ingress {
+    cidr_blocks = local.subnets
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+  }
+
+  // Allow all traffic to go out
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/internal/configs/embedded/trader-backend/tf-aws/sg.tf
+++ b/internal/configs/embedded/trader-backend/tf-aws/sg.tf
@@ -51,30 +51,6 @@ resource "aws_security_group" "ssh_docker_sg" {
   }
 }
 
-// Enable accessing RDS instance from private subnets
-resource "aws_security_group" "db_access" {
-  name_prefix = "d8x-cluster-posgtres-access-sg"
-  vpc_id      = aws_vpc.d8x_cluster_vpc.id
-
-  tags = {
-    Name = "d8x-cluster-posgtres-access-sg"
-  }
-
-  ingress {
-    cidr_blocks = local.subnets
-    from_port   = 5432
-    to_port     = 5432
-    protocol    = "tcp"
-  }
-
-  // Allow all traffic to go out
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-}
 
 resource "aws_security_group" "http_access" {
   name_prefix = "d8x-cluster-http-sg"


### PR DESCRIPTION
Previously, multiple deployments on AWS could not be created, because database identifier was hardcoded. This PR changes this, allowing to create multiple deploymens where some unique resources will be prefixed by provided server label.