### PR TITLE
Linode scaling fix

### DIFF
--- a/internal/actions/configure.go
+++ b/internal/actions/configure.go
@@ -100,9 +100,11 @@ func (c *Container) Configure(ctx *cli.Context) error {
 	cfg.ConfigDetails.Done = true
 	cfg.ConfigDetails.ConfiguredServers = c.HostsCfg.GetAllPublicIps()
 
-	// Update hosts.cfg
-	if err := c.LinodeInventorySetUserVar(cfg.ConfigDetails.ConfiguredServers, c.DefaultClusterUserName); err != nil {
-		return fmt.Errorf("updating linode inventory file: %w", err)
+	// Update hosts.cfg for linode provider
+	if cfg.ServerProvider == configs.D8XServerProviderLinode {
+		if err := c.LinodeInventorySetUserVar(cfg.ConfigDetails.ConfiguredServers, c.DefaultClusterUserName); err != nil {
+			return fmt.Errorf("updating linode inventory file: %w", err)
+		}
 	}
 
 	return c.ConfigRWriter.Write(cfg)

--- a/internal/actions/configure.go
+++ b/internal/actions/configure.go
@@ -58,7 +58,8 @@ func (c *Container) Configure(ctx *cli.Context) error {
 	configureUser := cfg.GetAnsibleUser()
 
 	// For linode when subsequent configuration is performed, we need to use the
-	// cluster user and provide become_pass for old servers
+	// cluster user and provide become_pass for old servers, but new servers
+	// need root.
 
 	// Generate ansible-playbook args
 	args := []string{
@@ -72,17 +73,39 @@ func (c *Container) Configure(ctx *cli.Context) error {
 		"./playbooks/setup.ansible.yaml",
 	}
 
-	// For AWS, we don't want to setup UFW, since firewall is already handled by
-	// AWS itself
-	if cfg.ServerProvider == configs.D8XServerProviderAWS {
+	switch cfg.ServerProvider {
+	case configs.D8XServerProviderAWS:
+		// For AWS, we don't want to setup UFW, since firewall is already handled by
+		// AWS itself
 		args = append(args, "--extra-vars", "no_ufw=true")
+
+	case configs.D8XServerProviderLinode:
+		// For linode - pass become_pass for subsequent configuration runs.
+		if cfg.ConfigDetails.Done {
+			args = append(args,
+				"--extra-vars", fmt.Sprintf(`ansible_become_pass='%s'`, c.UserPassword),
+			)
+		}
 	}
 
 	cmd := exec.Command("ansible-playbook", args...)
 	cmd.Env = os.Environ()
 	connectCMDToCurrentTerm(cmd)
 
-	return c.RunCmd(cmd)
+	if err := c.RunCmd(cmd); err != nil {
+		return err
+	}
+
+	// Update configuration details
+	cfg.ConfigDetails.Done = true
+	cfg.ConfigDetails.ConfiguredServers = c.HostsCfg.GetAllPublicIps()
+
+	// Update hosts.cfg
+	if err := c.LinodeInventorySetUserVar(cfg.ConfigDetails.ConfiguredServers, c.DefaultClusterUserName); err != nil {
+		return fmt.Errorf("updating linode inventory file: %w", err)
+	}
+
+	return c.ConfigRWriter.Write(cfg)
 }
 
 func generatePassword(n int) (string, error) {

--- a/internal/actions/tf_destroy.go
+++ b/internal/actions/tf_destroy.go
@@ -64,15 +64,7 @@ func (c *Container) TerraformDestroy(ctx *cli.Context) error {
 	}
 
 	// Update d8x config values and set deployment statuses to false
-	cfg.MetricsDeployed = false
-	cfg.BrokerDeployed = false
-	cfg.SwarmDeployed = false
-
-	cfg.SwarmCertbotDeployed = false
-	cfg.BrokerCertbotDeployed = false
-
-	cfg.SwarmNginxDeployed = false
-	cfg.BrokerNginxDeployed = false
+	cfg.ResetDeploymentStatus()
 
 	return c.ConfigRWriter.Write(cfg)
 }

--- a/internal/configs/d8x.go
+++ b/internal/configs/d8x.go
@@ -84,6 +84,36 @@ type D8XConfig struct {
 
 	// MD5 hash of last created ssh private key, empty string initially
 	SSHKeyMD5 string `json:"ssh_key_hash"`
+
+	// Ansible related configuration details
+	ConfigDetails ConfigurationDetails `json:"configuration_details"`
+}
+
+type ConfigurationDetails struct {
+	// Whether at least 1 time configuration was done successfully
+	Done bool `json:"done"`
+
+	// List of IP addresses of servers which were configured previously. This is
+	// important for linode configuration step when non-first time setup is
+	// performed. We use this list to mark which servers should use cluster user
+	// instead of root for ssh access in configure action.
+	ConfiguredServers []string `json:"configured_server_ip_addresses"`
+}
+
+// ResetDeploymentStatus cleans up deployment status of all services/servers,
+// etc. Should be called and stored after tf-destroy.
+func (d *D8XConfig) ResetDeploymentStatus() {
+	d.MetricsDeployed = false
+	d.BrokerDeployed = false
+	d.BrokerNginxDeployed = false
+	d.BrokerCertbotDeployed = false
+	d.SwarmDeployed = false
+	d.SwarmNginxDeployed = false
+	d.SwarmCertbotDeployed = false
+	d.ConfigDetails = ConfigurationDetails{
+		Done:              false,
+		ConfiguredServers: []string{},
+	}
 }
 
 type ReferralConfig struct {


### PR DESCRIPTION
This PR fixes problems for multiple runs of `setup` on provisioned servers for linode (or when workers number is changed). Previously we were not able to run `setup` on already configured servers because of ssh `PermitRootLogin` is set to `no` and inital sudo user for linode is only `root`. On subsequent configuration runs we append `ansible_user` as `d8xtrader` in `hosts.cfg` which fixes the access issues for ansible.