### PR TITLE
Pg backup

### DIFF
--- a/internal/actions/db_backup.go
+++ b/internal/actions/db_backup.go
@@ -1,0 +1,91 @@
+package actions
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/D8-X/d8x-cli/internal/conn"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/pkg/sftp"
+	"github.com/urfave/cli/v2"
+)
+
+// BackupDb performs database backup
+func (c *Container) BackupDb(ctx *cli.Context) error {
+	cfg, err := c.ConfigRWriter.Read()
+	if err != nil {
+		return err
+	}
+
+	ip, err := c.HostsCfg.GetMangerPublicIp()
+	if err != nil {
+		return fmt.Errorf("could not find manager ip: %w", err)
+	}
+
+	if len(cfg.DatabaseDSN) == 0 {
+		return fmt.Errorf("database dsn is not set in config")
+	}
+
+	// Parse the database dsn string
+	pgCfg, err := pgconn.ParseConfig(cfg.DatabaseDSN)
+	if err != nil {
+		return fmt.Errorf("parsing database connection string: %w", err)
+	}
+
+	// SSH into the manager
+	managerConn, err := conn.NewSSHConnection(ip, c.DefaultClusterUserName, c.SshKeyPath)
+	if err != nil {
+		return fmt.Errorf("creating ssh connection to manager: %w", err)
+	}
+
+	pwd, err := c.GetPassword(ctx)
+	if err != nil {
+		return err
+	}
+	// Make sure pg dump is installed on the manager
+	cmd := fmt.Sprintf(
+		`echo "%s" | sudo -S apt-get install -y postgresql-client-common`,
+		pwd,
+	)
+	managerConn.ExecCommand(cmd)
+
+	// Run pg dump for the database
+	backupFileName := fmt.Sprintf("backup-%s-%s.dump", cfg.GetServersLabel(), time.Now().Format("2006-01-02-15-04-05"))
+	backupCmd := "PGPASSWORD=%s pg_dump -h %s -p %d -U %s -d %s -F c -f %s"
+	backupCmd = fmt.Sprintf(backupCmd, pgCfg.Password, pgCfg.Host, pgCfg.Port, pgCfg.User, pgCfg.Database, backupFileName)
+
+	// TODO handle different versions and incompatible pg_dump and postgres
+
+	fmt.Printf("Creating database %s backup\n", pgCfg.Database)
+	if err := managerConn.ExecCommandPiped(backupCmd); err != nil {
+		return fmt.Errorf("running pg_dump: %w", err)
+	}
+
+	fmt.Println("Copying backup file to local machine")
+	// Use scp or similar library to copy the backup to given location on the
+	// local machine
+	scp, err := sftp.NewClient(managerConn.GetClient())
+	if err != nil {
+		return err
+	}
+	f, err := scp.OpenFile(backupFileName, os.O_RDONLY)
+	if err != nil {
+		return fmt.Errorf("opening backup file on manager: %w", err)
+	}
+
+	// Create backup file in current dir
+	// TOODO use directory flag
+	fout, err := os.OpenFile(backupFileName, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0666)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(fout, f); err != nil {
+		return err
+	}
+
+	fmt.Printf("Backup file %s was downloaded", backupFileName)
+
+	return nil
+}

--- a/internal/actions/db_backup.go
+++ b/internal/actions/db_backup.go
@@ -1,18 +1,26 @@
 package actions
 
 import (
+	"context"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/D8-X/d8x-cli/internal/conn"
 	"github.com/D8-X/d8x-cli/internal/styles"
-	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5"
 	"github.com/pkg/sftp"
 	"github.com/urfave/cli/v2"
 )
+
+// Latest available stable postgresql client version to use.
+const CurrentMaximumPostgresVersion = 16
 
 // BackupDb performs database backup
 func (c *Container) BackupDb(ctx *cli.Context) error {
@@ -33,7 +41,7 @@ func (c *Container) BackupDb(ctx *cli.Context) error {
 	}
 
 	// Parse the database dsn string
-	pgCfg, err := pgconn.ParseConfig(cfg.DatabaseDSN)
+	pgCfg, err := pgx.ParseConfig(cfg.DatabaseDSN)
 	if err != nil {
 		return fmt.Errorf("parsing database connection string: %w", err)
 	}
@@ -49,15 +57,55 @@ func (c *Container) BackupDb(ctx *cli.Context) error {
 		return err
 	}
 
+	// Retrieve the postgres version on target database
+	fmt.Printf("Determining postgres version\n")
+	pgConn, err := pgConnTunnel(managerConn, pgCfg)
+	if err != nil {
+		return err
+	}
+	row := pgConn.QueryRow(context.Background(), "select version()")
+	versionString := ""
+	if err := row.Scan(&versionString); err != nil {
+		return fmt.Errorf("retrieving postgres connection version: %w", err)
+	}
+	re := regexp.MustCompile(`PostgreSQL ([0-9]+)\.?([0-9]+).*`)
+	versionMatches := re.FindStringSubmatch(versionString)
+	if len(versionMatches) >= 3 {
+		majorVersion := versionMatches[1]
+		minorVersion := versionMatches[2]
+		versionString = majorVersion + "." + minorVersion
+
+	}
+	fmt.Printf("Postgres server at %s version: %s\n", pgCfg.Host, versionString)
+
+	// We default to maximum postgresq-client-x version available since it is
+	// backwards compatible.
+	cmd := "apt-cache search --names-only ^postgresql-client-* | awk '{print $1}'"
+	pgClientPackages, err := managerConn.ExecCommand(cmd)
+	maxPgVersion := CurrentMaximumPostgresVersion
+	if err != nil {
+		for _, pkgName := range strings.Split(string(pgClientPackages), "\n") {
+			versionStr := strings.TrimPrefix(
+				strings.TrimSpace(pkgName),
+				"postgresql-client-",
+			)
+			// Parse only whole int versions
+			if version, err := strconv.ParseInt(versionStr, 10, 64); err == nil && maxPgVersion < int(version) {
+				maxPgVersion = int(version)
+			}
+		}
+	}
+	aptPgClientPackage := "postgresql-client-" + strconv.Itoa(maxPgVersion)
+
 	// Make sure pg dump (postgres 15) is installed on the manager. Let's use
 	// the public postgres apt repo and set it up. It contains all latest
 	// versions of postgres
-	fmt.Println("Ensuring pg_dump is installed on manager server")
+	fmt.Printf("Ensuring pg_dump is installed on manager server (%s)\n", aptPgClientPackage)
 	installScriptSteps := []string{
 		`echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list`,
 		"wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -",
 		"apt-get update -y",
-		"apt-get -y install postgresql-client-15",
+		"apt-get -y install " + aptPgClientPackage,
 	}
 	for _, s := range installScriptSteps {
 		cmd := fmt.Sprintf(`echo "%s" | sudo -S bash -c '%s'`, pwd, s)
@@ -134,4 +182,12 @@ func (c *Container) BackupDb(ctx *cli.Context) error {
 	}
 
 	return nil
+}
+
+func pgConnTunnel(manager conn.SSHConnection, pgCfg *pgx.ConnConfig) (*pgx.Conn, error) {
+	pgCfg.DialFunc = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		return manager.GetClient().DialContext(ctx, network, addr)
+	}
+
+	return pgx.ConnectConfig(context.Background(), pgCfg)
 }

--- a/internal/cmd/main.go
+++ b/internal/cmd/main.go
@@ -160,6 +160,16 @@ func RunD8XCli() {
 				Usage:       "Copy configuration files to current working directory",
 				Description: "Copy specified configuration files to current working directory. Available configs are swarm, broker, tf-aws, tf-linode.",
 			},
+			{
+				Name:   "backup-db",
+				Action: container.BackupDb,
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Usage: "Backup directory path. Backup files will be saved in this directory.",
+					},
+				},
+				Description: "Backup database to local machine. Database credentials are read from d8x.conf.json file.",
+			},
 		},
 		// Global flags accessible to all subcommands
 		Flags: []cli.Flag{

--- a/internal/cmd/main.go
+++ b/internal/cmd/main.go
@@ -165,6 +165,7 @@ func RunD8XCli() {
 				Action: container.BackupDb,
 				Flags: []cli.Flag{
 					&cli.StringFlag{
+						Name:  "output-dir",
 						Usage: "Backup directory path. Backup files will be saved in this directory.",
 					},
 				},

--- a/internal/components/runner.go
+++ b/internal/components/runner.go
@@ -14,7 +14,7 @@ type ComponentsRunner interface {
 	NewList(listItems []ListItem, listTitle string, opts ...ListOpt) (ListItem, error)
 	NewPrompt(question string, confirmed bool) (bool, error)
 	NewSelection(selection []string, opts ...SelectionOpts) ([]string, error)
-	NewSpinner() error
+	NewSpinner(done chan struct{}, text string) error
 	NewTimer(timeout time.Duration, title string) error
 }
 
@@ -43,8 +43,8 @@ func (InteractiveRunner) NewSelection(selection []string, opts ...SelectionOpts)
 	return newSelection(selection, opts...)
 }
 
-func (InteractiveRunner) NewSpinner() error {
-	return newSpinner()
+func (InteractiveRunner) NewSpinner(done chan struct{}, text string) error {
+	return newSpinner(done, text)
 }
 
 func (InteractiveRunner) NewTimer(timeout time.Duration, title string) error {

--- a/internal/configs/d8x.go
+++ b/internal/configs/d8x.go
@@ -89,6 +89,20 @@ type D8XConfig struct {
 	ConfigDetails ConfigurationDetails `json:"configuration_details"`
 }
 
+func (c *D8XConfig) GetServersLabel() string {
+	switch c.ServerProvider {
+	case D8XServerProviderAWS:
+		if c.AWSConfig != nil {
+			return c.AWSConfig.LabelPrefix
+		}
+	case D8XServerProviderLinode:
+		if c.LinodeConfig != nil {
+			return c.LinodeConfig.LabelPrefix
+		}
+	}
+	return "d8x-cluster"
+}
+
 type ConfigurationDetails struct {
 	// Whether at least 1 time configuration was done successfully
 	Done bool `json:"done"`

--- a/internal/mocks/components.go
+++ b/internal/mocks/components.go
@@ -124,17 +124,17 @@ func (mr *MockComponentsRunnerMockRecorder) NewSelection(arg0 interface{}, arg1 
 }
 
 // NewSpinner mocks base method.
-func (m *MockComponentsRunner) NewSpinner() error {
+func (m *MockComponentsRunner) NewSpinner(arg0 chan struct{}, arg1 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewSpinner")
+	ret := m.ctrl.Call(m, "NewSpinner", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // NewSpinner indicates an expected call of NewSpinner.
-func (mr *MockComponentsRunnerMockRecorder) NewSpinner() *gomock.Call {
+func (mr *MockComponentsRunnerMockRecorder) NewSpinner(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewSpinner", reflect.TypeOf((*MockComponentsRunner)(nil).NewSpinner))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewSpinner", reflect.TypeOf((*MockComponentsRunner)(nil).NewSpinner), arg0, arg1)
 }
 
 // NewTimer mocks base method.

--- a/internal/mocks/conn.go
+++ b/internal/mocks/conn.go
@@ -9,6 +9,7 @@ import (
 
 	conn "github.com/D8-X/d8x-cli/internal/conn"
 	gomock "go.uber.org/mock/gomock"
+	ssh "golang.org/x/crypto/ssh"
 )
 
 // MockSSHConnection is a mock of SSHConnection interface.
@@ -79,4 +80,18 @@ func (m *MockSSHConnection) ExecCommandPiped(arg0 string) error {
 func (mr *MockSSHConnectionMockRecorder) ExecCommandPiped(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecCommandPiped", reflect.TypeOf((*MockSSHConnection)(nil).ExecCommandPiped), arg0)
+}
+
+// GetClient mocks base method.
+func (m *MockSSHConnection) GetClient() *ssh.Client {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetClient")
+	ret0, _ := ret[0].(*ssh.Client)
+	return ret0
+}
+
+// GetClient indicates an expected call of GetClient.
+func (mr *MockSSHConnectionMockRecorder) GetClient() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClient", reflect.TypeOf((*MockSSHConnection)(nil).GetClient))
 }

--- a/internal/mocks/files.go
+++ b/internal/mocks/files.go
@@ -97,6 +97,20 @@ func (m *MockHostsFileInteractor) EXPECT() *MockHostsFileInteractorMockRecorder 
 	return m.recorder
 }
 
+// GetAllPublicIps mocks base method.
+func (m *MockHostsFileInteractor) GetAllPublicIps() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAllPublicIps")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// GetAllPublicIps indicates an expected call of GetAllPublicIps.
+func (mr *MockHostsFileInteractorMockRecorder) GetAllPublicIps() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllPublicIps", reflect.TypeOf((*MockHostsFileInteractor)(nil).GetAllPublicIps))
+}
+
 // GetBrokerPublicIp mocks base method.
 func (m *MockHostsFileInteractor) GetBrokerPublicIp() (string, error) {
 	m.ctrl.T.Helper()
@@ -112,6 +126,36 @@ func (mr *MockHostsFileInteractorMockRecorder) GetBrokerPublicIp() *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBrokerPublicIp", reflect.TypeOf((*MockHostsFileInteractor)(nil).GetBrokerPublicIp))
 }
 
+// GetLines mocks base method.
+func (m *MockHostsFileInteractor) GetLines() ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLines")
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLines indicates an expected call of GetLines.
+func (mr *MockHostsFileInteractorMockRecorder) GetLines() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLines", reflect.TypeOf((*MockHostsFileInteractor)(nil).GetLines))
+}
+
+// GetMangerPrivateIp mocks base method.
+func (m *MockHostsFileInteractor) GetMangerPrivateIp() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMangerPrivateIp")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMangerPrivateIp indicates an expected call of GetMangerPrivateIp.
+func (mr *MockHostsFileInteractorMockRecorder) GetMangerPrivateIp() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMangerPrivateIp", reflect.TypeOf((*MockHostsFileInteractor)(nil).GetMangerPrivateIp))
+}
+
 // GetMangerPublicIp mocks base method.
 func (m *MockHostsFileInteractor) GetMangerPublicIp() (string, error) {
 	m.ctrl.T.Helper()
@@ -125,6 +169,50 @@ func (m *MockHostsFileInteractor) GetMangerPublicIp() (string, error) {
 func (mr *MockHostsFileInteractorMockRecorder) GetMangerPublicIp() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMangerPublicIp", reflect.TypeOf((*MockHostsFileInteractor)(nil).GetMangerPublicIp))
+}
+
+// GetWorkerIps mocks base method.
+func (m *MockHostsFileInteractor) GetWorkerIps() ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWorkerIps")
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetWorkerIps indicates an expected call of GetWorkerIps.
+func (mr *MockHostsFileInteractorMockRecorder) GetWorkerIps() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkerIps", reflect.TypeOf((*MockHostsFileInteractor)(nil).GetWorkerIps))
+}
+
+// GetWorkerPrivateIps mocks base method.
+func (m *MockHostsFileInteractor) GetWorkerPrivateIps() ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWorkerPrivateIps")
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetWorkerPrivateIps indicates an expected call of GetWorkerPrivateIps.
+func (mr *MockHostsFileInteractorMockRecorder) GetWorkerPrivateIps() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkerPrivateIps", reflect.TypeOf((*MockHostsFileInteractor)(nil).GetWorkerPrivateIps))
+}
+
+// WriteLines mocks base method.
+func (m *MockHostsFileInteractor) WriteLines(arg0 []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WriteLines", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WriteLines indicates an expected call of WriteLines.
+func (mr *MockHostsFileInteractorMockRecorder) WriteLines(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteLines", reflect.TypeOf((*MockHostsFileInteractor)(nil).WriteLines), arg0)
 }
 
 // MockFSInteractor is a mock of FSInteractor interface.


### PR DESCRIPTION
**Change Description:**

This PR adds `backup-db` subcommand for backing up the deployment database. See README.md for explanation on how to use it. 

When running `backup-db`, latest available version of `pg_dump` will be installed on manager server. `pg_dump` is backwards compatible with older versions of postgres server. Tested with `pg_dump` 16 with postgres server 13
