### PR TITLE
Small changes

### DIFF
--- a/internal/configs/embedded/playbooks/broker.ansible.yaml
+++ b/internal/configs/embedded/playbooks/broker.ansible.yaml
@@ -35,3 +35,10 @@
         src: /snap/bin/certbot
         dest: /usr/bin/certbot
         state: link
+      # Make sure the certbot snap timer is enabled after certbot snap
+      # installation
+    - name: Enable certbot renewal
+      ansible.builtin.systemd:
+        name: snap.certbot.renew.timer
+        enabled: true
+        state: started

--- a/internal/configs/embedded/playbooks/nginx.ansible.yaml
+++ b/internal/configs/embedded/playbooks/nginx.ansible.yaml
@@ -51,3 +51,10 @@
         src: /snap/bin/certbot
         dest: /usr/bin/certbot
         state: link
+      # Make sure the certbot snap timer is enabled after certbot snap
+      # installation
+    - name: Enable certbot renewal
+      ansible.builtin.systemd:
+        name: snap.certbot.renew.timer
+        enabled: true
+        state: started

--- a/internal/configs/embedded/playbooks/setup.ansible.yaml
+++ b/internal/configs/embedded/playbooks/setup.ansible.yaml
@@ -38,7 +38,7 @@
           - sudo
           - adm
         shell: /bin/bash
-        password: "{{ default_user_pwd | password_hash('sha512') }}"
+        password: "{{ default_user_pwd }}"
     - name: "Set authorized key for default user"
       ansible.posix.authorized_key:
         # user_public_key must be passed via --extra-vars


### PR DESCRIPTION
Changed generation of user's password hash. Removed the use of deprecated ansible filter. Password for user is now generated in go.

Ensure certbot renewal systemd timer is enabled after certbot installation. 