### PR TITLE
Db tunnel and small tweaks

### DIFF
--- a/internal/actions/db_tunnel.go
+++ b/internal/actions/db_tunnel.go
@@ -1,0 +1,93 @@
+package actions
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+
+	"github.com/D8-X/d8x-cli/internal/conn"
+	"github.com/D8-X/d8x-cli/internal/styles"
+	"github.com/jackc/pgx/v5"
+	"github.com/urfave/cli/v2"
+)
+
+func (c *Container) DbTunnel(ctx *cli.Context) error {
+	styles.PrintCommandTitle("Esablishing ssh tunnel to database...")
+
+	targetLocalPort := ctx.Args().Get(0)
+
+	// Default to 5432
+	port := "5432"
+	if targetLocalPort != "" {
+		_, err := strconv.ParseInt(targetLocalPort, 10, 64)
+		if err != nil {
+			return fmt.Errorf("please provde a valid port number: %w", err)
+		}
+		port = targetLocalPort
+	}
+
+	cfg, err := c.ConfigRWriter.Read()
+	if err != nil {
+		return err
+	}
+
+	ip, err := c.HostsCfg.GetMangerPublicIp()
+	if err != nil {
+		return fmt.Errorf("could not find manager ip: %w", err)
+	}
+
+	if len(cfg.DatabaseDSN) == 0 {
+		return fmt.Errorf("database dsn is not set in config")
+	}
+
+	// Parse the database dsn string
+	pgCfg, err := pgx.ParseConfig(cfg.DatabaseDSN)
+	if err != nil {
+		return fmt.Errorf("parsing database connection string: %w", err)
+	}
+
+	// Bind local socket
+	l, err := net.Listen("tcp", "127.0.0.1:"+port)
+	if err != nil {
+		return fmt.Errorf("binding listener on port %s: %w", port, err)
+	}
+
+	// SSH into the manager
+	managerConn, err := conn.NewSSHConnection(ip, c.DefaultClusterUserName, c.SshKeyPath)
+	if err != nil {
+		return fmt.Errorf("creating ssh connection to manager: %w", err)
+	}
+
+	cpIo := func(w io.Writer, r io.Reader) error {
+		_, err := io.Copy(w, r)
+		return err
+	}
+
+	fmt.Printf("Connecting to database %s via manager server\n\n", pgCfg.Host)
+
+	fmt.Println(styles.SuccessText.Render("Use the following credentials on this machine to connect to the database:"))
+	fmt.Printf("Database user: %s\n", pgCfg.User)
+	fmt.Printf("Database password: %s\n", pgCfg.Password)
+	fmt.Printf("Database name: %s\n", pgCfg.Database)
+	fmt.Printf("Database host: %s\n", "127.0.0.1")
+	fmt.Printf("Database port: %s\n", port)
+
+	fmt.Println(styles.GrayText.Render("Press Ctrl+C to exit"))
+
+	for {
+		conn, err := l.Accept()
+		if err != nil {
+			return err
+		}
+		defer conn.Close()
+
+		dbConn, err := managerConn.GetClient().Dial("tcp", pgCfg.Host+":"+strconv.Itoa(int(pgCfg.Port)))
+		if err != nil {
+			return fmt.Errorf("dialing database on manager: %w", err)
+		}
+
+		go cpIo(dbConn, conn)
+		go cpIo(conn, dbConn)
+	}
+}

--- a/internal/actions/input.go
+++ b/internal/actions/input.go
@@ -1071,7 +1071,7 @@ func (c *InputCollector) SwarmNginxCollectDomains(cfg *configs.D8XConfig) ([]hos
 
 		// When possible, find values from config for non-first time runs.
 		// Provide some automatic subdomain suggestions by default
-		value := cfg.SuggestSubdomain(h.serviceName, c.ChainJson.GetChainType(strconv.Itoa(int(cfg.ChainId))))
+		value := cfg.SuggestSubdomain(h.serviceName, c.ChainJson.GetChainType(strconv.Itoa(int(cfg.ChainId))), cfg.ChainId)
 		if v, ok := cfg.Services[h.serviceName]; ok {
 			if v.HostName != "" {
 				value = v.HostName

--- a/internal/actions/provision_aws.go
+++ b/internal/actions/provision_aws.go
@@ -123,6 +123,7 @@ func (c *InputCollector) CollectAwProviderDetails(cfg *configs.D8XConfig) (awsCo
 	awsRDSInstanceClass := "db.t4g.small"
 	awsServerLabelPrefix := "d8x-cluster"
 	awsDefaultNumberWorkers := "4"
+	awsDefaultRegion := "eu-central-1"
 
 	if cfg.AWSConfig != nil {
 		awsKey = cfg.AWSConfig.AccesKey
@@ -135,6 +136,9 @@ func (c *InputCollector) CollectAwProviderDetails(cfg *configs.D8XConfig) (awsCo
 		}
 		if cfg.AWSConfig.NumWorker != 0 {
 			awsDefaultNumberWorkers = strconv.Itoa(cfg.AWSConfig.NumWorker)
+		}
+		if cfg.AWSConfig.Region != "" {
+			awsDefaultRegion = cfg.AWSConfig.Region
 		}
 	}
 
@@ -163,8 +167,9 @@ func (c *InputCollector) CollectAwProviderDetails(cfg *configs.D8XConfig) (awsCo
 	awsCfg.SecretKey = secretKey
 
 	fmt.Println("Enter your AWS cluster region: ")
+
 	region, err := c.TUI.NewInput(
-		components.TextInputOptValue("eu-central-1"),
+		components.TextInputOptValue(awsDefaultRegion),
 		components.TextInputOptPlaceholder("us-west-1"),
 	)
 	if err != nil {

--- a/internal/actions/ssh.go
+++ b/internal/actions/ssh.go
@@ -136,7 +136,7 @@ func (c *Container) GetWorkerConnection(workerIp string, cfg *configs.D8XConfig)
 
 		// Workers are accessible through manager for AWS
 		managerConn, errMngr := conn.NewSSHConnection(managerIp, c.DefaultClusterUserName, c.SshKeyPath)
-		if err != nil {
+		if errMngr != nil {
 			return nil, errMngr
 		}
 		cn, connErr = conn.NewSSHConnectionWithBastion(managerConn.GetClient(), workerIp, c.DefaultClusterUserName, c.SshKeyPath)

--- a/internal/cmd/main.go
+++ b/internal/cmd/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"slices"
 
 	"github.com/D8-X/d8x-cli/internal/actions"
 	"github.com/D8-X/d8x-cli/internal/configs"
@@ -53,6 +54,9 @@ func RunD8XCli() {
 		Usage:                CmdUsage,
 		Description:          MainDescription,
 		EnableBashCompletion: true,
+		CommandNotFound: func(ctx *cli.Context, s string) {
+			fmt.Printf("Unknown command %s\n", s)
+		},
 		Commands: []*cli.Command{
 
 			{
@@ -74,6 +78,23 @@ func RunD8XCli() {
 							fmt.Printf("User password retrieved from %s\n", configs.DEFAULT_PASSWORD_FILE)
 						}
 					}
+
+					subcommands := []string{
+						"provision",
+						"configure",
+						"broker-deploy",
+						"broker-nginx",
+						"swarm-deploy",
+						"swarm-nginx",
+						"metrics-deploy",
+					}
+
+					subcommand := ctx.Args().First()
+
+					if slices.Index(subcommands, subcommand) == -1 {
+						return fmt.Errorf("setup command does not have subcommand %s", subcommand)
+					}
+
 					return nil
 				},
 				Flags: []cli.Flag{provisionTfDirFlag},
@@ -170,6 +191,12 @@ func RunD8XCli() {
 					},
 				},
 				Description: "Backup database to local machine. Database credentials are read from d8x.conf.json file.",
+			},
+			{
+				Name:        "db-tunnel",
+				Action:      container.DbTunnel,
+				ArgsUsage:   "[local port 5432]",
+				Description: "Create a ssh tunnel to database server. Database credentials are read from d8x.conf.json file.",
 			},
 		},
 		// Global flags accessible to all subcommands

--- a/internal/cmd/main.go
+++ b/internal/cmd/main.go
@@ -91,7 +91,7 @@ func RunD8XCli() {
 
 					subcommand := ctx.Args().First()
 
-					if slices.Index(subcommands, subcommand) == -1 {
+					if subcommand != "" && slices.Index(subcommands, subcommand) == -1 {
 						return fmt.Errorf("setup command does not have subcommand %s", subcommand)
 					}
 

--- a/internal/configs/d8x.go
+++ b/internal/configs/d8x.go
@@ -281,13 +281,13 @@ func (d *d8xConfigFileReadWriter) Write(cfg *D8XConfig) error {
 	return nil
 }
 
-func (c *D8XConfig) SuggestSubdomain(svc D8XServiceName, chainName string) string {
+func (c *D8XConfig) SuggestSubdomain(svc D8XServiceName, chainName string, chainId uint) string {
 	if c.SetupDomain == "" {
 		return ""
 	}
 
 	if subdomain, ok := SuggestedSubdomains[svc]; ok {
-		return fmt.Sprintf("%s-%s.%s", subdomain, chainName, c.SetupDomain)
+		return fmt.Sprintf("%s-%s-%d.%s", subdomain, chainName, chainId, c.SetupDomain)
 	}
 	return ""
 }


### PR DESCRIPTION
This PR introduces `db-tunnel` subcommand. Also show error message when non-existing subcommand was used. Bugfix to take the default region from config for aws setuop