### PR TITLE
Add optional .env file support for broker, allowedExecutors bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,3 +506,8 @@ using manager server as jump host.
 	- username: `user` value from `aws_rds_postgres.txt`
 	- password: `password` value from `aws_rds_postgres.txt`
 6. Inspect the database
+
+# Broker .env
+
+You can place `.env` file in the `broker-server` directory. This file will be
+copied to the broker server and used as env file for broker compose services.

--- a/internal/actions/broker.go
+++ b/internal/actions/broker.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"slices"
 	"strconv"
 	"strings"
 
@@ -31,7 +30,6 @@ func UpdateBrokerChainConfigAllowedExecutors(allowedExecutorAddress string) func
 			if len(allowedExecutorAddress) > 0 {
 				executors = append(executors, allowedExecutorAddress)
 			}
-
 			// Make sure we don't overwrite existing allowedExecutors
 			v, ok := conf["allowedExecutors"].([]any)
 			if ok {
@@ -41,8 +39,10 @@ func UpdateBrokerChainConfigAllowedExecutors(allowedExecutorAddress string) func
 					}
 				}
 			}
-			executors = slices.Compact(executors)
-			conf["allowedExecutors"] = executors
+
+			// Remove duplicates
+			conf["allowedExecutors"] = UniqStrings(executors)
+
 			// Update the entry
 			(*chainConfig)[i] = conf
 		}
@@ -83,6 +83,10 @@ var (
 	brokerDeployChainConfig   = "./broker-server/chainConfig.json"
 	brokerDeployRpcConfig     = "./broker-server/rpc.json"
 	brokerDeployDockerCompose = "./broker-server/docker-compose.yml"
+
+	// Optional .env file path. If found, this .env file will be copied to the
+	// broker-server deployment.
+	brokerEnvFile = "./broker-server/.env"
 )
 
 func (c *Container) CopyBrokerDeployConfigs() error {
@@ -188,6 +192,15 @@ func (c *Container) BrokerDeploy(ctx *cli.Context) error {
 		conn.SftpCopySrcDest{Src: brokerDeployDockerCompose, Dst: "./broker/docker-compose.yml"},
 	); err != nil {
 		return err
+	}
+
+	// Optional. Copy the .env file to broker dir on server if it exists
+	if _, err := os.Stat(brokerEnvFile); err == nil {
+		if err := sshClient.CopyFilesOverSftp(
+			conn.SftpCopySrcDest{Src: brokerEnvFile, Dst: "./broker/.env"},
+		); err != nil {
+			return err
+		}
 	}
 
 	// Prepare the volume with unencrypted keyfile for storing private key which

--- a/internal/actions/utils.go
+++ b/internal/actions/utils.go
@@ -19,3 +19,17 @@ func PrivateKeyToAddress(pk string) (common.Address, error) {
 func ValidWalletAddress(address string) bool {
 	return regexp.MustCompile("^0x[0-9a-fA-F]{40}$").MatchString(address)
 }
+
+func UniqStrings(slice []string) []string {
+	uniq := make(map[string]struct{})
+	for _, s := range slice {
+		uniq[s] = struct{}{}
+	}
+
+	var result []string
+	for s := range uniq {
+		result = append(result, s)
+	}
+
+	return result
+}

--- a/internal/configs/embedded/broker-server/docker-compose.yml
+++ b/internal/configs/embedded/broker-server/docker-compose.yml
@@ -29,7 +29,9 @@ services:
       - rpc_config
     volumes:
       - keyvol:/keyfile
-
+    env_file:
+      - path: .env
+        required: false
   executorws:
     image: ghcr.io/d8-x/d8x-broker-exec-ws:main
     #build:
@@ -54,6 +56,9 @@ services:
         max-file: "10"
     configs:
       - chain_config
+    env_file:
+      - path: .env
+        required: false
 
   redis:
     image: redis


### PR DESCRIPTION
If `.env` file is present in `broker-server` deployment directory, it will be uploaded to the `broker` directory on broker server and used as optional env file for broker services.

Also added allowed executors in chain config duplicates removal