### PR TITLE
Ingress fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,14 @@ On the broker server, inspect the services with `docker ps` and look at the log
 files with `cd broker` and `docker compose logs -f`. Redeploy changed configs
 via `d8x setup broker-deploy`
 
+Sometimes swarm cluster deployment ingress network can get stuck on manager
+server. This might result in HTTP 503 errors or `Connection refused` message
+when trying to curl swarm services on manager server. To fix this you can re-run
+`d8x setup swarm-deploy` command which attempts to fix "broker" ingress network
+after deploying swarm services. There is also individual subcommand `d8x
+fix-ingress` which does only the ingress network fixing part, but requires to
+rerun `swarm-deploy` command afterwards.
+
 </details>
 <details>
   <summary>How do I update the swarm server software images to a new version?</summary>

--- a/internal/actions/ingress_fix.go
+++ b/internal/actions/ingress_fix.go
@@ -1,0 +1,91 @@
+package actions
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/D8-X/d8x-cli/internal/conn"
+	"github.com/D8-X/d8x-cli/internal/styles"
+	"github.com/urfave/cli/v2"
+)
+
+func (c *Container) IngressFix(ctx *cli.Context) error {
+	pwd, err := c.GetPassword(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Remove the ingress on manager
+	ip, err := c.HostsCfg.GetMangerPublicIp()
+	if err != nil {
+		return err
+	}
+	managerConn, err := conn.NewSSHConnection(ip, c.DefaultClusterUserName, c.SshKeyPath)
+	if err != nil {
+		return err
+	}
+
+	// Remove the stack and ingress network
+	fmt.Println("Removing stack and ingress network")
+	if _, err := managerConn.ExecCommand(
+		fmt.Sprintf("docker stack rm %s && yes | docker network rm ingress -f", dockerStackName),
+	); err != nil {
+		return fmt.Errorf("removing stack and ingress network: %w", err)
+	} else {
+		fmt.Println(styles.SuccessText.Render("Successfully removed stack and ingress network"))
+	}
+
+	fmt.Println("Recreating ingress network")
+	time.Sleep(5 * time.Second)
+	// Recreate ingress
+	if _, err := managerConn.ExecCommand("docker network create -d overlay --subnet 172.16.1.0/24 --ingress ingress"); err != nil {
+		return fmt.Errorf("recreating ingress network: %w", err)
+	} else {
+		fmt.Println(styles.SuccessText.Render("Successfully recreated ingress network"))
+	}
+
+	fmt.Println("Restarting docker daemons")
+
+	// Restart the manager's docker
+	if _, err := managerConn.ExecCommand(
+		fmt.Sprintf(`echo "%s"| sudo -S systemctl restart docker`, pwd),
+	); err != nil {
+		return fmt.Errorf("restarting manager's docker: %w", err)
+	} else {
+		fmt.Println(styles.SuccessText.Render("Successfully restarted docker on manager"))
+	}
+
+	workerIps, err := c.HostsCfg.GetWorkerIps()
+	if err != nil {
+		return err
+	}
+
+	// Reboot all workers
+	wg := sync.WaitGroup{}
+	for n, ip := range workerIps {
+		n := n
+		wg.Add(1)
+		go func(ip string) {
+			workerNum := n + 1
+			defer wg.Done()
+			workerConn, err := conn.NewSSHConnectionWithBastion(managerConn.GetClient(), ip, c.DefaultClusterUserName, c.SshKeyPath)
+			if err != nil {
+				info := fmt.Sprintf("creating ssh connection to worker-%d %s: %s", workerNum, ip, err.Error())
+				fmt.Println(styles.ErrorText.Render(info))
+			}
+
+			if _, err := workerConn.ExecCommand(
+				fmt.Sprintf(`echo "%s"| sudo -S systemctl restart docker`, pwd),
+			); err != nil {
+				return
+			} else {
+				fmt.Println(styles.SuccessText.Render("Successfully restarted docker on worker-" + strconv.Itoa(workerNum)))
+			}
+		}(ip)
+	}
+	wg.Wait()
+
+	return nil
+}

--- a/internal/actions/swarm.go
+++ b/internal/actions/swarm.go
@@ -148,6 +148,7 @@ func (c *Container) SwarmDeploy(ctx *cli.Context) error {
 			}
 
 			// Redeploy the swarm after ingress fix
+			fmt.Println(styles.ItalicText.Render("Redeploying swarm services after ingress fix..."))
 			if err := c.swarmDeploy(ctx, false); err != nil {
 				return err
 			}

--- a/internal/actions/swarm.go
+++ b/internal/actions/swarm.go
@@ -1,6 +1,7 @@
 package actions
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -129,6 +130,46 @@ func (c *Container) CopySwarmDeployConfigs() error {
 func (c *Container) SwarmDeploy(ctx *cli.Context) error {
 	styles.PrintCommandTitle("Starting swarm cluster deployment...")
 
+	if err := c.swarmDeploy(ctx, true); err != nil {
+		return err
+	}
+
+	// After swarm deployment is completed, check if ingress network is working
+	// correctly on manager. Repeat for 2 times max
+	ingressWorks := false
+	for i := 0; i < 2; i++ {
+		fmt.Printf("Checking ingress network on manager... (attempt %d/2)\n", i+1)
+		err := c.CheckSwarmIngressIsCorrect(ctx)
+		if err != nil {
+			fmt.Println(styles.ErrorText.Render(err.Error()))
+			if err := c.IngressFix(ctx); err != nil {
+				fmt.Println(styles.SuccessText.Render(fmt.Sprintf("Ingress network fix failed: %s\n", err.Error())))
+				continue
+			}
+
+			// Redeploy the swarm after ingress fix
+			if err := c.swarmDeploy(ctx, false); err != nil {
+				return err
+			}
+
+		} else {
+			fmt.Println(styles.SuccessText.Render("Ingress network is working correctly on manager"))
+			ingressWorks = true
+			break
+		}
+	}
+
+	if !ingressWorks {
+		fmt.Println(styles.ErrorText.Render("Ingress network is not working correctly on manager"))
+		fmt.Println("Automatic fix failed, please try to run fix-ingress and setup swarm-deploy manually")
+	}
+
+	return nil
+}
+
+// swarmDeploy performs the swarm deployment step
+func (c *Container) swarmDeploy(ctx *cli.Context, showConfigConfirmation bool) error {
+
 	// Find manager ip before we start collecting data in case manager is not
 	// available.
 	managerIp, err := c.HostsCfg.GetMangerPublicIp()
@@ -233,12 +274,14 @@ func (c *Container) SwarmDeploy(ctx *cli.Context) error {
 		return fmt.Errorf("temp storage of keyfile failed: %w", err)
 	}
 
-	fmt.Println(styles.AlertImportant.Render("Please verify your .env and configuration files are correct before proceeding."))
-	fmt.Println("The following configuration files will be copied to the 'manager node' for the d8x-trader-backend swarm deployment:")
-	for _, f := range swarmDeployConfigFilesToCopy[:6] {
-		fmt.Println(f.Dst)
+	if showConfigConfirmation {
+		fmt.Println(styles.AlertImportant.Render("Please verify your .env and configuration files are correct before proceeding."))
+		fmt.Println("The following configuration files will be copied to the 'manager node' for the d8x-trader-backend swarm deployment:")
+		for _, f := range swarmDeployConfigFilesToCopy[:6] {
+			fmt.Println(f.Dst)
+		}
+		c.TUI.NewConfirmation("Press enter to confirm that the configuration files listed above are good to go...")
 	}
-	c.TUI.NewConfirmation("Press enter to confirm that the configuration files listed above are good to go...")
 
 	pwd, err := c.GetPassword(ctx)
 	if err != nil {
@@ -664,4 +707,54 @@ var hostsTpl = []hostnameTuple{
 		find:        "%candles_ws%",
 		serviceName: configs.D8XServiceCandlesWs,
 	},
+}
+
+type NameIp struct {
+	Name string `json:"name"`
+	IP   string `json:"IP"`
+}
+
+// CheckSwarmIngressIsCorrect checks if swarm manager's ingress network
+// configuration contains worker servers as peers and is in correct state
+func (c *Container) CheckSwarmIngressIsCorrect(ctx *cli.Context) error {
+	// Check if ingress's peers property contains all the workers on manager
+	managerIp, err := c.HostsCfg.GetMangerPublicIp()
+	if err != nil {
+		return err
+	}
+	managerConn, err := conn.NewSSHConnection(managerIp, c.DefaultClusterUserName, c.SshKeyPath)
+	if err != nil {
+		return err
+	}
+
+	out, err := managerConn.ExecCommand(`docker network inspect -f "{{json .Peers}}" ingress`)
+	if err != nil {
+		return err
+	}
+	peers := []NameIp{}
+	if err := json.Unmarshal([]byte(out), &peers); err != nil {
+		return fmt.Errorf("parsing docker network inspect output: %w", err)
+	}
+
+	// Check if all workers are present in peers list
+	workerIps, err := c.HostsCfg.GetWorkerPrivateIps()
+	if err != nil {
+		return err
+	}
+
+	for _, workerIp := range workerIps {
+		found := false
+		for _, peer := range peers {
+			if workerIp == peer.IP {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return fmt.Errorf("worker with IP %s is not present in ingress network peers", workerIp)
+		}
+	}
+
+	return nil
 }

--- a/internal/cmd/main.go
+++ b/internal/cmd/main.go
@@ -201,6 +201,11 @@ func RunD8XCli() {
 				ArgsUsage:   "[local port 5432]",
 				Description: "Create a ssh tunnel to database server. Database credentials are read from d8x.conf.json file.",
 			},
+			{
+				Name:   "fix-ingress",
+				Usage:  "Fix faulty ingress network",
+				Action: container.IngressFix,
+			},
 		},
 		// Global flags accessible to all subcommands
 		Flags: []cli.Flag{


### PR DESCRIPTION
This PR adds additional ingress network checks after `swam-deploy` step. Ingress network is checked on manager server to contain all worker servers as `Peers`. If peers list is incomplete - ingress network is recreated, docker daemons restarted and swarm services redeployed automatically. In case `Peers` list is correct, no additional actions are taken. 

- Tested on both AWS and Linode
- Testing sequence:
	- Run `setup`
	- Manually recreate ingress on manager
	- Rerun `swarm-deploy` -> ingress fix step is performed correctly