### PR TITLE
adjust to pyth v2 and use http endpoints only

### DIFF
--- a/internal/actions/swarm_test.go
+++ b/internal/actions/swarm_test.go
@@ -18,14 +18,11 @@ func TestUpdateReferralSettingsBrokerPayoutAddress(t *testing.T) {
 
 func TestUpdateCandlesPriceConfigPriceServices(t *testing.T) {
 	pricesConf := &map[string]any{
-		"priceServiceWSEndpoints":    []string{"some-ws-endpoint"},
 		"priceServiceHTTPSEndpoints": []string{},
 	}
 	err := UpdateCandlesPriceConfigPriceServices(
-		[]string{"new-ws-1", "new-ws-2"},
-		[]string{"new-http-endpoint-service"},
+		[]string{"new-http-endpoint-service", "new-http-endpoint-service1", "new-http-endpoint-service12"},
 	)(pricesConf)
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"new-ws-1", "new-ws-2"}, (*pricesConf)["priceServiceWSEndpoints"])
-	assert.Equal(t, []string{"new-http-endpoint-service"}, (*pricesConf)["priceServiceHTTPSEndpoints"])
+	assert.Equal(t, []string{"new-http-endpoint-service", "new-http-endpoint-service1", "new-http-endpoint-service12"}, (*pricesConf)["priceServiceHTTPSEndpoints"])
 }

--- a/internal/configs/d8x.go
+++ b/internal/configs/d8x.go
@@ -87,6 +87,10 @@ type D8XConfig struct {
 
 	// Ansible related configuration details
 	ConfigDetails ConfigurationDetails `json:"configuration_details"`
+
+	// Pyth/triton, etc. User supplied price feed endpoints which will be added
+	// to prices.config.json
+	UserSuppliedPriceFeedEndpoints []string `json:"user_supplied_price_feed_endpoints"`
 }
 
 func (c *D8XConfig) GetServersLabel() string {

--- a/internal/configs/embedded/candles/prices.config.json
+++ b/internal/configs/embedded/candles/prices.config.json
@@ -1,5 +1,4 @@
 {
-  "priceServiceHTTPSEndpoints": [],
   "pythAPIEndpoint": "https://benchmarks.pyth.network/",
-  "priceServiceWSEndpoints": ["wss://hermes.pyth.network/ws"]
+  "priceServiceHTTPSEndpoints": []
 }

--- a/internal/configs/embedded/trader-backend/chain.json
+++ b/internal/configs/embedded/trader-backend/chain.json
@@ -3,56 +3,48 @@
     "type": "testnet",
     "sdkNetwork": "x1",
     "priceFeedNetwork": "pythnet",
-    "priceServiceWSEndpoint": "wss://hermes.pyth.network/ws",
-    "priceServiceHTTPSEndpoint": "https://odin.d8x.xyz/api"
+    "priceServiceHTTPSEndpoint": "https://odin.d8x.xyz"
   },
   "1101": {
     "type": "mainnet",
     "sdkNetwork": "zkevm",
     "priceFeedNetwork": "mainnet",
-    "priceServiceWSEndpoint": "wss://hermes.pyth.network/ws",
-    "priceServiceHTTPSEndpoint": ""
+    "priceServiceHTTPSEndpoint": "https://hermes.pyth.network/"
   },
   "2442": {
     "type": "testnet",
     "sdkNetwork": "cardona",
     "priceFeedNetwork": "mainnet",
-    "priceServiceWSEndpoint": "wss://hermes.pyth.network/ws",
-    "priceServiceHTTPSEndpoint": "https://odin.d8x.xyz/api"
+    "priceServiceHTTPSEndpoint": "https://odin.d8x.xyz"
   },
   "421614": {
     "type": "testnet",
     "sdkNetwork": "arbitrumSepolia",
     "priceFeedNetwork": "mainnet",
-    "priceServiceWSEndpoint": "wss://hermes.pyth.network/ws",
-    "priceServiceHTTPSEndpoint": ""
+    "priceServiceHTTPSEndpoint": "https://hermes.pyth.network/"
   },
   "42161": {
     "type": "mainnet",
     "sdkNetwork": "arbitrum",
     "priceFeedNetwork": "mainnet",
-    "priceServiceWSEndpoint": "wss://hermes.pyth.network/ws",
-    "priceServiceHTTPSEndpoint": ""
+    "priceServiceHTTPSEndpoint": "https://hermes.pyth.network/"
   },
   "80084": {
     "type": "testnet",
     "sdkNetwork": "bartio",
     "priceFeedNetwork": "mainnet",
-    "priceServiceWSEndpoint": "wss://hermes.pyth.network/ws",
-    "priceServiceHTTPSEndpoint": ""
+    "priceServiceHTTPSEndpoint": "https://hermes.pyth.network/"
   },
   "196": {
     "type": "mainnet",
     "sdkNetwork": "xlayer",
     "priceFeedNetwork": "mainnet",
-    "priceServiceWSEndpoint": "wss://hermes.pyth.network/ws",
-    "priceServiceHTTPSEndpoint": "https://odin.d8x.xyz/api"
+    "priceServiceHTTPSEndpoint": "https://odin.d8x.xyz"
   },
   "default": {
     "type": "mainnet",
     "sdkNetwork": "zkevm",
     "priceFeedNetwork": "mainnet",
-    "priceServiceWSEndpoint": "wss://hermes.pyth.network/ws",
-    "priceServiceHTTPSEndpoint": ""
+    "priceServiceHTTPSEndpoint": "https://hermes.pyth.network/"
   }
 }


### PR DESCRIPTION
This PR removes old pyth websockets configs and makes http ones as the default 