### PR TITLE
Nginx rate limits

### DIFF
--- a/internal/actions/input.go
+++ b/internal/actions/input.go
@@ -135,6 +135,12 @@ type SwarmNginxInput struct {
 
 	// Collected service domain names
 	collectedServiceDomains []hostnameTuple
+
+	// If selected, set_real_ip_from directives with cloudflare ips will be
+	// added to the nginx server config/
+	setupWithCloudflareIps bool
+
+	setupNginxRateLimiting bool
 }
 
 // Whether deployment is broker only
@@ -685,6 +691,18 @@ func (input *InputCollector) CollectSwarmNginxInputs(ctx *cli.Context) error {
 	}
 	input.swarmNginxInput.setupCertbot = setupCertbot
 
+	// Cloudflare and rate limiting
+	useCloudflare, err := input.TUI.NewPrompt("Will you use Cloudflare DNS proxying?", true)
+	if err != nil {
+		return err
+	}
+	input.swarmNginxInput.setupWithCloudflareIps = useCloudflare
+	useRateLimiting, err := input.TUI.NewPrompt("Do you want to setup Nginx rate limiting?", true)
+	if err != nil {
+		return err
+	}
+	input.swarmNginxInput.setupNginxRateLimiting = useRateLimiting
+
 	// Collect domain name
 	_, err = input.CollectSetupDomain(cfg)
 	if err != nil {
@@ -704,7 +722,6 @@ func (input *InputCollector) CollectSwarmNginxInputs(ctx *cli.Context) error {
 	}
 
 	input.swarmNginxInput.collected = true
-
 	return nil
 }
 

--- a/internal/actions/swarm_test.go
+++ b/internal/actions/swarm_test.go
@@ -1,9 +1,14 @@
 package actions
 
 import (
+	"bytes"
+	"errors"
+	"io"
 	"testing"
+	"testing/iotest"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUpdateReferralSettingsBrokerPayoutAddress(t *testing.T) {
@@ -25,4 +30,56 @@ func TestUpdateCandlesPriceConfigPriceServices(t *testing.T) {
 	)(pricesConf)
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"new-http-endpoint-service", "new-http-endpoint-service1", "new-http-endpoint-service12"}, (*pricesConf)["priceServiceHTTPSEndpoints"])
+}
+
+func TestProcessNginxConfigComments(t *testing.T) {
+
+	tests := []struct {
+		name              string
+		inputNginxConfig  io.Reader
+		inputNginxSection NginxConfigSection
+		wantOutput        []byte
+		wantErr           string
+	}{
+		{
+			name:              "should fail reading input",
+			inputNginxConfig:  iotest.ErrReader(errors.New("read error")),
+			inputNginxSection: "",
+			wantErr:           "read error",
+			wantOutput:        []byte{},
+		},
+		{
+			name: "should process one section correctly",
+			inputNginxConfig: bytes.NewReader([]byte(`
+# some comment	
+# another comment
+# {thing}
+sdfsdf
+# this line shall be uncommented
+#{\thing}	
+			`)),
+			inputNginxSection: "thing",
+			wantOutput: []byte(`
+# some comment	
+# another comment
+# {thing}
+sdfsdf
+ this line shall be uncommented
+#{\thing}	
+			`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output, err := processNginxConfigComments(tt.inputNginxConfig, tt.inputNginxSection)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Equal(t, tt.wantErr, err.Error())
+			} else {
+				assert.Equal(t, string(tt.wantOutput), string(output))
+			}
+		})
+	}
+
 }

--- a/internal/configs/embedded/nginx/nginx.conf
+++ b/internal/configs/embedded/nginx/nginx.conf
@@ -6,8 +6,12 @@ server {
     server_name %main%;
     listen 80;
 
-    limit_req_zone $binary_remote_addr zone=one:10m rate=1r/s;
-    limit_req zone=one burst=5;
+    # Rate limiting for main api with up to 10 requests
+    # burst
+    #
+    # {enable_rate_limiting} 
+    #limit_req zone=primary_zone burst=10;
+    # {/enable_rate_limiting}
 
     location / {
         # Change the port if needed
@@ -29,6 +33,13 @@ server {
 server {
     server_name %main_ws%;
     listen 80;
+
+    # Rate limiting for main websockets with up to 3 requests
+    # burst
+    #
+    # {enable_rate_limiting} 
+    #limit_req zone=primary_zone burst=3;
+    # {/enable_rate_limiting}
 
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "SAMEORIGIN" always;
@@ -64,6 +75,13 @@ server {
     server_name %history%;
     listen 80;
 
+    # Rate limiting for history with up to 3 requests
+    # burst
+    #
+    # {enable_rate_limiting} 
+    #limit_req zone=primary_zone burst=3;
+    # {/enable_rate_limiting}
+
     location / {
         # Change the port if needed
         proxy_pass http://127.0.0.1:3003;
@@ -84,6 +102,13 @@ server {
 server {
     server_name %referral%;
     listen 80;
+
+    # Rate limiting for referral with up to 3 requests
+    # burst
+    #
+    # {enable_rate_limiting} 
+    #limit_req zone=primary_zone burst=3;
+    # {/enable_rate_limiting}
 
     location / {
         # CORS
@@ -111,6 +136,13 @@ server {
     server_name %candles_ws%;
     listen 80;
     
+    # Rate limiting for candles with up to 3 requests
+    # burst
+    #
+    # {enable_rate_limiting} 
+    #limit_req zone=primary_zone burst=3;
+    # {/enable_rate_limiting}
+
     location / {
         # Change the port if needed
         proxy_pass http://127.0.0.1:3005/ws;

--- a/internal/configs/embedded/nginx/nginx.conf
+++ b/internal/configs/embedded/nginx/nginx.conf
@@ -10,7 +10,7 @@ server {
     # burst
     #
     # {enable_rate_limiting} 
-    #limit_req zone=primary_zone burst=10;
+    #limit_req zone=primary_zone burst=10 nodelay;
     # {/enable_rate_limiting}
 
     location / {
@@ -38,7 +38,7 @@ server {
     # burst
     #
     # {enable_rate_limiting} 
-    #limit_req zone=primary_zone burst=3;
+    #limit_req zone=primary_zone burst=3 nodelay;
     # {/enable_rate_limiting}
 
     add_header X-Content-Type-Options "nosniff" always;
@@ -79,7 +79,7 @@ server {
     # burst
     #
     # {enable_rate_limiting} 
-    #limit_req zone=primary_zone burst=3;
+    #limit_req zone=primary_zone burst=3 nodelay;
     # {/enable_rate_limiting}
 
     location / {
@@ -107,7 +107,7 @@ server {
     # burst
     #
     # {enable_rate_limiting} 
-    #limit_req zone=primary_zone burst=3;
+    #limit_req zone=primary_zone burst=3 nodelay;
     # {/enable_rate_limiting}
 
     location / {
@@ -140,7 +140,7 @@ server {
     # burst
     #
     # {enable_rate_limiting} 
-    #limit_req zone=primary_zone burst=3;
+    #limit_req zone=primary_zone burst=3 nodelay;
     # {/enable_rate_limiting}
 
     location / {

--- a/internal/configs/embedded/nginx/nginx.conf
+++ b/internal/configs/embedded/nginx/nginx.conf
@@ -6,6 +6,9 @@ server {
     server_name %main%;
     listen 80;
 
+    limit_req_zone $binary_remote_addr zone=one:10m rate=1r/s;
+    limit_req zone=one burst=5;
+
     location / {
         # Change the port if needed
         proxy_pass http://127.0.0.1:3001; 

--- a/internal/configs/embedded/nginx/nginx.server.conf
+++ b/internal/configs/embedded/nginx/nginx.server.conf
@@ -10,8 +10,8 @@ events {
 
 http {
 
-	# Cloudflare real ip setup (cloudflare.com/ips-v4). Do not remove the next
-	# comment line 
+	# Cloudflare real ip setup (cloudflare.com/ips-v4). Do not edit this
+	# comment.
 	#
 	# {real_ip_cloudflare}
 	#
@@ -34,7 +34,10 @@ http {
 	#real_ip_header CF-Connecting-IP;
 	# 
 	# {/real_ip_cloudflare}
-	# Do not remove above comment line
+
+	# {enable_rate_limiting}
+	#limit_req_zone $binary_remote_addr zone=primary_zone:10m rate=5r/s; 
+	# {/enable_rate_limiting}
 
 	# Increase hash bucket size for longer server names
 	server_names_hash_bucket_size 128;

--- a/internal/configs/embedded/nginx/nginx.server.conf
+++ b/internal/configs/embedded/nginx/nginx.server.conf
@@ -9,6 +9,33 @@ events {
 }
 
 http {
+
+	# Cloudflare real ip setup (cloudflare.com/ips-v4). Do not remove the next
+	# comment line 
+	#
+	# {real_ip_cloudflare}
+	#
+	#set_real_ip_from 173.245.48.0/20;
+	#set_real_ip_from 103.21.244.0/22;
+	#set_real_ip_from 103.22.200.0/22;
+	#set_real_ip_from 103.31.4.0/22;
+	#set_real_ip_from 141.101.64.0/18;
+	#set_real_ip_from 108.162.192.0/18;
+	#set_real_ip_from 190.93.240.0/20;
+	#set_real_ip_from 188.114.96.0/20;
+	#set_real_ip_from 197.234.240.0/22;
+	#set_real_ip_from 198.41.128.0/17;
+	#set_real_ip_from 162.158.0.0/15;
+	#set_real_ip_from 104.16.0.0/13;
+	#set_real_ip_from 104.24.0.0/14;
+	#set_real_ip_from 172.64.0.0/13;
+	#set_real_ip_from 131.0.72.0/22;
+	#
+	#real_ip_header CF-Connecting-IP;
+	# 
+	# {/real_ip_cloudflare}
+	# Do not remove above comment line
+
 	# Increase hash bucket size for longer server names
 	server_names_hash_bucket_size 128;
 

--- a/internal/configs/embedded/nginx/nginx.server.conf
+++ b/internal/configs/embedded/nginx/nginx.server.conf
@@ -36,7 +36,7 @@ http {
 	# {/real_ip_cloudflare}
 
 	# {enable_rate_limiting}
-	#limit_req_zone $binary_remote_addr zone=primary_zone:10m rate=5r/s; 
+	#limit_req_zone $binary_remote_addr zone=primary_zone:10m rate=10r/s; 
 	# {/enable_rate_limiting}
 
 	# Increase hash bucket size for longer server names


### PR DESCRIPTION
This PR introduces new nginx configuration functionality for trader-backend deployments. 

- Users can choose to use real_ip module with cloudflare proxying, this sets the remote ip address to actual user's IP address instead of Cloudflare proxy
- Users can choose to enable rate limiting in directly in nginx configuration, rate limiting is performed per IP address.

Users are prompted to enable these options during nginx configuration step in the setup process. 

Current rate limit is set to 5 requests per second with varying bursts per service. 

Tested from 2 different IP addresses with a setup behind CF proxy. Rate limiting based on IP seems to work correctly. Rate limited requests will return HTTP 503.