### PR TITLE
[ON HOLD] Remove NETWORK_NAME env

### DIFF
--- a/internal/actions/input.go
+++ b/internal/actions/input.go
@@ -135,6 +135,12 @@ type SwarmNginxInput struct {
 
 	// Collected service domain names
 	collectedServiceDomains []hostnameTuple
+
+	// If selected, set_real_ip_from directives with cloudflare ips will be
+	// added to the nginx server config/
+	setupWithCloudflareIps bool
+
+	setupNginxRateLimiting bool
 }
 
 // Whether deployment is broker only
@@ -685,6 +691,18 @@ func (input *InputCollector) CollectSwarmNginxInputs(ctx *cli.Context) error {
 	}
 	input.swarmNginxInput.setupCertbot = setupCertbot
 
+	// Cloudflare and rate limiting
+	useCloudflare, err := input.TUI.NewPrompt("Will you use Cloudflare DNS proxying?", true)
+	if err != nil {
+		return err
+	}
+	input.swarmNginxInput.setupWithCloudflareIps = useCloudflare
+	useRateLimiting, err := input.TUI.NewPrompt("Do you want to setup Nginx rate limiting?", true)
+	if err != nil {
+		return err
+	}
+	input.swarmNginxInput.setupNginxRateLimiting = useRateLimiting
+
 	// Collect domain name
 	_, err = input.CollectSetupDomain(cfg)
 	if err != nil {
@@ -704,7 +722,6 @@ func (input *InputCollector) CollectSwarmNginxInputs(ctx *cli.Context) error {
 	}
 
 	input.swarmNginxInput.collected = true
-
 	return nil
 }
 

--- a/internal/actions/rpc.go
+++ b/internal/actions/rpc.go
@@ -16,7 +16,6 @@ import (
 
 type ChainJsonEntry struct {
 	SDKNetwork               string `json:"sdkNetwork"`
-	PriceFeedNetwork         string `json:"priceFeedNetwork"`
 	DefaultPythWSEndpoint    string `json:"priceServiceWSEndpoint"`
 	DefaultPythHTTPSEndpoint string `json:"priceServiceHTTPSEndpoint"`
 	// Chain type is either testnet or mainnet
@@ -214,15 +213,6 @@ func (c ChainJson) getChainSDKName(chainId string) string {
 		return c["default"].SDKNetwork
 	}
 	return entry.SDKNetwork
-}
-
-// getChainPriceFeedName retrieves the python compatible NETWORK_NAME
-func (c ChainJson) getChainPriceFeedName(chainId string) string {
-	entry, exists := c[chainId]
-	if !exists {
-		return c["default"].PriceFeedNetwork
-	}
-	return entry.PriceFeedNetwork
 }
 
 // getDefaultPythWSEndpoint retrieves the default pyth websocket endpoint from

--- a/internal/actions/swarm.go
+++ b/internal/actions/swarm.go
@@ -52,7 +52,6 @@ func (c *Container) EditSwarmEnv(envPath string, cfg *configs.D8XConfig) error {
 
 	// We assume that all cfg values are present at this point
 	findReplaceOrCreateEnvs := map[string]string{
-		"NETWORK_NAME":       c.cachedChainJson.getChainPriceFeedName(strconv.Itoa(int(cfg.ChainId))),
 		"SDK_CONFIG_NAME":    c.cachedChainJson.getChainSDKName(strconv.Itoa(int(cfg.ChainId))),
 		"CHAIN_ID":           strconv.Itoa(int(cfg.ChainId)),
 		"REDIS_PASSWORD":     cfg.SwarmRedisPassword,

--- a/internal/actions/swarm_test.go
+++ b/internal/actions/swarm_test.go
@@ -1,9 +1,14 @@
 package actions
 
 import (
+	"bytes"
+	"errors"
+	"io"
 	"testing"
+	"testing/iotest"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUpdateReferralSettingsBrokerPayoutAddress(t *testing.T) {
@@ -25,4 +30,56 @@ func TestUpdateCandlesPriceConfigPriceServices(t *testing.T) {
 	)(pricesConf)
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"new-http-endpoint-service", "new-http-endpoint-service1", "new-http-endpoint-service12"}, (*pricesConf)["priceServiceHTTPSEndpoints"])
+}
+
+func TestProcessNginxConfigComments(t *testing.T) {
+
+	tests := []struct {
+		name              string
+		inputNginxConfig  io.Reader
+		inputNginxSection NginxConfigSection
+		wantOutput        []byte
+		wantErr           string
+	}{
+		{
+			name:              "should fail reading input",
+			inputNginxConfig:  iotest.ErrReader(errors.New("read error")),
+			inputNginxSection: "",
+			wantErr:           "read error",
+			wantOutput:        []byte{},
+		},
+		{
+			name: "should process one section correctly",
+			inputNginxConfig: bytes.NewReader([]byte(`
+# some comment	
+# another comment
+# {thing}
+sdfsdf
+# this line shall be uncommented
+#{\thing}	
+			`)),
+			inputNginxSection: "thing",
+			wantOutput: []byte(`
+# some comment	
+# another comment
+# {thing}
+sdfsdf
+ this line shall be uncommented
+#{\thing}	
+			`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output, err := processNginxConfigComments(tt.inputNginxConfig, tt.inputNginxSection)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Equal(t, tt.wantErr, err.Error())
+			} else {
+				assert.Equal(t, string(tt.wantOutput), string(output))
+			}
+		})
+	}
+
 }

--- a/internal/configs/embedded/docker-swarm-stack.yml
+++ b/internal/configs/embedded/docker-swarm-stack.yml
@@ -118,7 +118,6 @@ services:
       - REDIS_ADDR=redis:6379
       - REDIS_DB_NUM=0
       - CONFIG_PATH=/cfg_prices
-      - NETWORK_NAME=${NETWORK_NAME}
     networks:
       - candles
       - d8x_backend

--- a/internal/configs/embedded/nginx/nginx.conf
+++ b/internal/configs/embedded/nginx/nginx.conf
@@ -6,8 +6,12 @@ server {
     server_name %main%;
     listen 80;
 
-    limit_req_zone $binary_remote_addr zone=one:10m rate=1r/s;
-    limit_req zone=one burst=5;
+    # Rate limiting for main api with up to 10 requests
+    # burst
+    #
+    # {enable_rate_limiting} 
+    #limit_req zone=primary_zone burst=10;
+    # {/enable_rate_limiting}
 
     location / {
         # Change the port if needed
@@ -29,6 +33,13 @@ server {
 server {
     server_name %main_ws%;
     listen 80;
+
+    # Rate limiting for main websockets with up to 3 requests
+    # burst
+    #
+    # {enable_rate_limiting} 
+    #limit_req zone=primary_zone burst=3;
+    # {/enable_rate_limiting}
 
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "SAMEORIGIN" always;
@@ -64,6 +75,13 @@ server {
     server_name %history%;
     listen 80;
 
+    # Rate limiting for history with up to 3 requests
+    # burst
+    #
+    # {enable_rate_limiting} 
+    #limit_req zone=primary_zone burst=3;
+    # {/enable_rate_limiting}
+
     location / {
         # Change the port if needed
         proxy_pass http://127.0.0.1:3003;
@@ -84,6 +102,13 @@ server {
 server {
     server_name %referral%;
     listen 80;
+
+    # Rate limiting for referral with up to 3 requests
+    # burst
+    #
+    # {enable_rate_limiting} 
+    #limit_req zone=primary_zone burst=3;
+    # {/enable_rate_limiting}
 
     location / {
         # CORS
@@ -111,6 +136,13 @@ server {
     server_name %candles_ws%;
     listen 80;
     
+    # Rate limiting for candles with up to 3 requests
+    # burst
+    #
+    # {enable_rate_limiting} 
+    #limit_req zone=primary_zone burst=3;
+    # {/enable_rate_limiting}
+
     location / {
         # Change the port if needed
         proxy_pass http://127.0.0.1:3005/ws;

--- a/internal/configs/embedded/nginx/nginx.conf
+++ b/internal/configs/embedded/nginx/nginx.conf
@@ -10,7 +10,7 @@ server {
     # burst
     #
     # {enable_rate_limiting} 
-    #limit_req zone=primary_zone burst=10;
+    #limit_req zone=primary_zone burst=10 nodelay;
     # {/enable_rate_limiting}
 
     location / {
@@ -38,7 +38,7 @@ server {
     # burst
     #
     # {enable_rate_limiting} 
-    #limit_req zone=primary_zone burst=3;
+    #limit_req zone=primary_zone burst=3 nodelay;
     # {/enable_rate_limiting}
 
     add_header X-Content-Type-Options "nosniff" always;
@@ -79,7 +79,7 @@ server {
     # burst
     #
     # {enable_rate_limiting} 
-    #limit_req zone=primary_zone burst=3;
+    #limit_req zone=primary_zone burst=3 nodelay;
     # {/enable_rate_limiting}
 
     location / {
@@ -107,7 +107,7 @@ server {
     # burst
     #
     # {enable_rate_limiting} 
-    #limit_req zone=primary_zone burst=3;
+    #limit_req zone=primary_zone burst=3 nodelay;
     # {/enable_rate_limiting}
 
     location / {
@@ -140,7 +140,7 @@ server {
     # burst
     #
     # {enable_rate_limiting} 
-    #limit_req zone=primary_zone burst=3;
+    #limit_req zone=primary_zone burst=3 nodelay;
     # {/enable_rate_limiting}
 
     location / {

--- a/internal/configs/embedded/nginx/nginx.conf
+++ b/internal/configs/embedded/nginx/nginx.conf
@@ -6,6 +6,9 @@ server {
     server_name %main%;
     listen 80;
 
+    limit_req_zone $binary_remote_addr zone=one:10m rate=1r/s;
+    limit_req zone=one burst=5;
+
     location / {
         # Change the port if needed
         proxy_pass http://127.0.0.1:3001; 

--- a/internal/configs/embedded/nginx/nginx.server.conf
+++ b/internal/configs/embedded/nginx/nginx.server.conf
@@ -10,8 +10,8 @@ events {
 
 http {
 
-	# Cloudflare real ip setup (cloudflare.com/ips-v4). Do not remove the next
-	# comment line 
+	# Cloudflare real ip setup (cloudflare.com/ips-v4). Do not edit this
+	# comment.
 	#
 	# {real_ip_cloudflare}
 	#
@@ -34,7 +34,10 @@ http {
 	#real_ip_header CF-Connecting-IP;
 	# 
 	# {/real_ip_cloudflare}
-	# Do not remove above comment line
+
+	# {enable_rate_limiting}
+	#limit_req_zone $binary_remote_addr zone=primary_zone:10m rate=5r/s; 
+	# {/enable_rate_limiting}
 
 	# Increase hash bucket size for longer server names
 	server_names_hash_bucket_size 128;

--- a/internal/configs/embedded/nginx/nginx.server.conf
+++ b/internal/configs/embedded/nginx/nginx.server.conf
@@ -9,6 +9,33 @@ events {
 }
 
 http {
+
+	# Cloudflare real ip setup (cloudflare.com/ips-v4). Do not remove the next
+	# comment line 
+	#
+	# {real_ip_cloudflare}
+	#
+	#set_real_ip_from 173.245.48.0/20;
+	#set_real_ip_from 103.21.244.0/22;
+	#set_real_ip_from 103.22.200.0/22;
+	#set_real_ip_from 103.31.4.0/22;
+	#set_real_ip_from 141.101.64.0/18;
+	#set_real_ip_from 108.162.192.0/18;
+	#set_real_ip_from 190.93.240.0/20;
+	#set_real_ip_from 188.114.96.0/20;
+	#set_real_ip_from 197.234.240.0/22;
+	#set_real_ip_from 198.41.128.0/17;
+	#set_real_ip_from 162.158.0.0/15;
+	#set_real_ip_from 104.16.0.0/13;
+	#set_real_ip_from 104.24.0.0/14;
+	#set_real_ip_from 172.64.0.0/13;
+	#set_real_ip_from 131.0.72.0/22;
+	#
+	#real_ip_header CF-Connecting-IP;
+	# 
+	# {/real_ip_cloudflare}
+	# Do not remove above comment line
+
 	# Increase hash bucket size for longer server names
 	server_names_hash_bucket_size 128;
 

--- a/internal/configs/embedded/trader-backend/chain.json
+++ b/internal/configs/embedded/trader-backend/chain.json
@@ -2,7 +2,8 @@
   "195": {
     "type": "testnet",
     "sdkNetwork": "x1",
-    "priceServiceHTTPSEndpoint": "https://odin.d8x.xyz"
+    "priceFeedNetwork": "pythnet",
+    "priceServiceHTTPSEndpoint": "https://hermes.pyth.network/"
   },
   "1101": {
     "type": "mainnet",
@@ -12,7 +13,7 @@
   "2442": {
     "type": "testnet",
     "sdkNetwork": "cardona",
-    "priceServiceHTTPSEndpoint": "https://odin.d8x.xyz"
+    "priceServiceHTTPSEndpoint": "https://hermes.pyth.network/"
   },
   "421614": {
     "type": "testnet",
@@ -32,7 +33,8 @@
   "196": {
     "type": "mainnet",
     "sdkNetwork": "xlayer",
-    "priceServiceHTTPSEndpoint": "https://odin.d8x.xyz"
+    "priceFeedNetwork": "mainnet",
+    "priceServiceHTTPSEndpoint": "https://hermes.pyth.network/"
   },
   "default": {
     "type": "mainnet",

--- a/internal/configs/embedded/trader-backend/chain.json
+++ b/internal/configs/embedded/trader-backend/chain.json
@@ -2,49 +2,41 @@
   "195": {
     "type": "testnet",
     "sdkNetwork": "x1",
-    "priceFeedNetwork": "pythnet",
     "priceServiceHTTPSEndpoint": "https://odin.d8x.xyz"
   },
   "1101": {
     "type": "mainnet",
     "sdkNetwork": "zkevm",
-    "priceFeedNetwork": "mainnet",
     "priceServiceHTTPSEndpoint": "https://hermes.pyth.network/"
   },
   "2442": {
     "type": "testnet",
     "sdkNetwork": "cardona",
-    "priceFeedNetwork": "mainnet",
     "priceServiceHTTPSEndpoint": "https://odin.d8x.xyz"
   },
   "421614": {
     "type": "testnet",
     "sdkNetwork": "arbitrumSepolia",
-    "priceFeedNetwork": "mainnet",
     "priceServiceHTTPSEndpoint": "https://hermes.pyth.network/"
   },
   "42161": {
     "type": "mainnet",
     "sdkNetwork": "arbitrum",
-    "priceFeedNetwork": "mainnet",
     "priceServiceHTTPSEndpoint": "https://hermes.pyth.network/"
   },
   "80084": {
     "type": "testnet",
     "sdkNetwork": "bartio",
-    "priceFeedNetwork": "mainnet",
     "priceServiceHTTPSEndpoint": "https://hermes.pyth.network/"
   },
   "196": {
     "type": "mainnet",
     "sdkNetwork": "xlayer",
-    "priceFeedNetwork": "mainnet",
     "priceServiceHTTPSEndpoint": "https://odin.d8x.xyz"
   },
   "default": {
     "type": "mainnet",
     "sdkNetwork": "zkevm",
-    "priceFeedNetwork": "mainnet",
     "priceServiceHTTPSEndpoint": "https://hermes.pyth.network/"
   }
 }

--- a/internal/configs/embedded/trader-backend/env.example
+++ b/internal/configs/embedded/trader-backend/env.example
@@ -2,10 +2,6 @@
 ### Environment variables listed below should be changed
 ###
 
-# PYTH NETWORK: mainnet/testnet
-NETWORK_NAME=testnet
-#NETWORK_NAME=mainnet
-
 # zkEVM testnet
 CHAIN_ID=1442
 SDK_CONFIG_NAME=zkevmTestnet


### PR DESCRIPTION
Should only be merged after https://github.com/D8-X/d8x-cli/pull/94

This PR removes `NETWORK_NAME` env variable from cli setup. 

`NETWORK_NAME` is not used outside of candles and default `mainnet` value is always set by default, therefore this env is not needed anymore. 