### PR TITLE
Ubuntu24

### DIFF
--- a/internal/actions/provision_linode.go
+++ b/internal/actions/provision_linode.go
@@ -56,7 +56,6 @@ func (c *Container) CopyLinodeTFFiles() error {
 			Overwrite: true,
 		},
 	)
-
 }
 
 // BuildTerraformCMD builds terraform configuration for linode cluster creation.
@@ -85,7 +84,7 @@ func (l linodeConfigurer) BuildTerraformCMD(c *Container) (*exec.Cmd, error) {
 func (l linodeConfigurer) generateArgs() []string {
 	args := []string{
 		"apply", "-auto-approve",
-		//"-var", fmt.Sprintf(`authorized_keys=["%s"]`, strings.TrimSpace(l.authorizedKey)),
+		"-var", fmt.Sprintf(`authorized_keys=["%s"]`, strings.TrimSpace(l.authorizedKey)),
 		"-var", fmt.Sprintf(`region=%s`, l.Region),
 		"-var", fmt.Sprintf(`server_label_prefix=%s`, l.LabelPrefix),
 		"-var", fmt.Sprintf(`create_broker_server=%t`, l.CreateBrokerServer),
@@ -170,7 +169,6 @@ func (c *InputCollector) CollectLinodeProviderDetails(cfg *configs.D8XConfig) (l
 		components.TextInputOptValue(defaultToken),
 		components.TextInputOptMasked(),
 	)
-
 	if err != nil {
 		return l, err
 	}

--- a/internal/configs/embedded/broker-server/chainConfig.json
+++ b/internal/configs/embedded/broker-server/chainConfig.json
@@ -40,6 +40,11 @@
     "allowedExecutors": []
   },
   {
+    "chainId": 84532,
+    "name": "base",
+    "allowedExecutors": []
+  },
+  {
     "chainId": 8453,
     "name": "base",
     "allowedExecutors": []

--- a/internal/configs/embedded/broker-server/chainConfig.json
+++ b/internal/configs/embedded/broker-server/chainConfig.json
@@ -35,6 +35,11 @@
     "allowedExecutors": []
   },
   {
+    "chainId": 80094,
+    "name": "bera",
+    "allowedExecutors": []
+  },
+  {
     "chainId": 8453,
     "name": "base",
     "allowedExecutors": []

--- a/internal/configs/embedded/broker-server/rpc.json
+++ b/internal/configs/embedded/broker-server/rpc.json
@@ -1,27 +1,40 @@
 [
   {
     "chainId": 1101,
-    "HTTP": ["https://zkevm-rpc.com"]
+    "HTTP": [
+      "https://zkevm-rpc.com"
+    ]
   },
   {
     "chainId": 195,
-    "HTTP": ["https://testrpc.xlayer.tech", "https://xlayertestrpc.okx.com/"]
+    "HTTP": [
+      "https://testrpc.xlayer.tech",
+      "https://xlayertestrpc.okx.com/"
+    ]
   },
   {
     "chainId": 196,
-    "HTTP": ["https://xlayerrpc.okx.com"]
+    "HTTP": [
+      "https://xlayerrpc.okx.com"
+    ]
   },
   {
     "chainId": 2442,
-    "HTTP": ["https://rpc.cardona.zkevm-rpc.com"]
+    "HTTP": [
+      "https://rpc.cardona.zkevm-rpc.com"
+    ]
   },
   {
     "chainId": 80084,
-    "HTTP": ["https://bartio.rpc.berachain.com/"]
+    "HTTP": [
+      "https://bartio.rpc.berachain.com/"
+    ]
   },
   {
     "chainId": 80094,
-    "HTTP": ["https://rpc.berachain.com/"]
+    "HTTP": [
+      "https://rpc.berachain.com/"
+    ]
   },
   {
     "chainId": 421614,
@@ -32,10 +45,20 @@
   },
   {
     "chainId": 42161,
-    "HTTP": ["https://arb1.arbitrum.io/rpc"]
+    "HTTP": [
+      "https://arb1.arbitrum.io/rpc"
+    ]
+  },
+  {
+    "chainId": 84532,
+    "HTTP": [
+      "https://sepolia.base.org"
+    ]
   },
   {
     "chainId": 8453,
-    "HTTP": ["https://mainnet.base.org"]
+    "HTTP": [
+      "https://mainnet.base.org"
+    ]
   }
 ]

--- a/internal/configs/embedded/broker-server/rpc.json
+++ b/internal/configs/embedded/broker-server/rpc.json
@@ -20,6 +20,10 @@
     "HTTP": ["https://bartio.rpc.berachain.com/"]
   },
   {
+    "chainId": 80094,
+    "HTTP": ["https://rpc.berachain.com/"]
+  },
+  {
     "chainId": 421614,
     "HTTP": [
       "https://sepolia-rollup.arbitrum.io/rpc",

--- a/internal/configs/embedded/playbooks/setup.ansible.yaml
+++ b/internal/configs/embedded/playbooks/setup.ansible.yaml
@@ -20,12 +20,31 @@
   handlers:
     - name: Restart SSHD
       ansible.builtin.service:
-        name: sshd
+        name: ssh
         state: restarted
+      # https://discourse.ubuntu.com/t/sshd-now-uses-socket-based-activation-ubuntu-22-10-and-later/30189
+      ignore_errors: true
   tasks:
     - name: Wait for connection to server
       ansible.builtin.wait_for_connection:
         timeout: 360
+    - name: Install essential packages
+      ansible.builtin.apt:
+        pkg:
+          - ca-certificates
+          - curl
+          - gnupg
+          - python3
+          - python3-pip
+          - git
+          - certbot
+          - nfs-common
+          # iptables-persistent is broken by ufw in ubuntu 24.04 and deb 12,
+          # therfore ufw will be removed automatically. Since we need
+          # iptables-persistent we will simply use iptables.
+          - iptables-persistent
+        state: latest
+        update_cache: true
     # Essentials, hostnames, users setup, ssh keys
     - name: Set hostname
       ansible.builtin.hostname:
@@ -55,47 +74,25 @@
         - { key: "PasswordAuthentication", value: "no" }
       notify:
         - Restart SSHD
-    # UFW configuration
-    - name: Allow port 22 ufw
-      community.general.ufw:
-        rule: allow
-        port: 22
+    # Firewall setup without ufw
+    - name: Configure iptables rules
+      ansible.builtin.shell:
+        cmd: |
+          iptables -A INPUT -i lo -j ACCEPT
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -p tcp --dport 22 -j ACCEPT
+          iptables -A INPUT -p tcp --dport 2377 -j ACCEPT
+          iptables -A INPUT -p tcp --dport 7946 -j ACCEPT
+          iptables -A INPUT -p udp --dport 7946 -j ACCEPT
+          iptables -A INPUT -p udp --dport 4789 -j ACCEPT
+          iptables -P INPUT DROP
+          iptables -P FORWARD DROP
       when: setup_ufw
-    # Docker swarm ports
-    - name: Allow port 2377 ufw
-      community.general.ufw:
-        rule: allow
-        port: 2377
-      when: setup_ufw
-    - name: Allow port 7946 ufw
-      community.general.ufw:
-        rule: allow
-        port: 7946
-      when: setup_ufw
-    - name: Allow port 4789 ufw
-      community.general.ufw:
-        rule: allow
-        port: 4789
-      when: setup_ufw
-    - name: Enable ufw
-      community.general.ufw:
-        state: enabled
+    - name: Persist iptables rules
+      ansible.builtin.shell:
+        cmd: iptables-save > /etc/iptables/rules.v4
       when: setup_ufw
     # Installation of docker
-    - name: Install essential packages
-      ansible.builtin.apt:
-        pkg:
-          - ca-certificates
-          - curl
-          - gnupg
-          - python3
-          - python3-pip
-          - git
-          - certbot
-          - nfs-common
-          - iptables-persistent
-        state: latest
-        update_cache: true
     - name: Get Docker apt repo key
       ansible.builtin.get_url:
         url: https://download.docker.com/linux/ubuntu/gpg
@@ -200,18 +197,15 @@
         state: started
 
     # HTTP(s) ports should be exposed only on manager
-    - name: Allow port 80 ufw
-      community.general.ufw:
-        rule: allow
-        port: 80
-        proto: tcp
+    - name: Allow ports 80, 443 iptables
+      ansible.builtin.shell:
+        cmd: |
+          iptables -A INPUT -p tcp --dport 80 -j ACCEPT
+          iptables -A INPUT -p tcp --dport 443 -j ACCEPT
       when: setup_ufw
-    - name: Allow port 443 ufw
-      community.general.ufw:
-        rule: allow
-        port: 443
-        proto: tcp
-        state: reloaded
+    - name: Persist iptables rules
+      ansible.builtin.shell:
+        cmd: iptables-save > /etc/iptables/rules.v4
       when: setup_ufw
 
 - hosts:

--- a/internal/configs/embedded/playbooks/setup.ansible.yaml
+++ b/internal/configs/embedded/playbooks/setup.ansible.yaml
@@ -116,6 +116,7 @@
           - containerd.io
           - docker-buildx-plugin
           - docker-compose-plugin
+          - python3-docker
         update_cache: true
     - name: Add default user to docker group
       ansible.builtin.user:
@@ -123,10 +124,11 @@
         groups:
           - docker
         append: true
-    - name: Install docker pip module
-      ansible.builtin.pip:
-        name:
-          - docker
+    # - name: Install docker pip module
+    #   ansible.builtin.pip:
+    #     name:
+    #       - docker
+    #
 
     # Docker swarm setup
     - name: Init a new swarm on manager with private ip address

--- a/internal/configs/embedded/trader-backend/chain.json
+++ b/internal/configs/embedded/trader-backend/chain.json
@@ -41,6 +41,12 @@
     "priceFeedNetwork": "mainnet",
     "priceServiceHTTPSEndpoint": "https://hermes.pyth.network/"
   },
+  "84532": {
+    "type": "testnet",
+    "sdkNetwork": "base_sepolia",
+    "priceFeedNetwork": "mainnet",
+    "priceServiceHTTPSEndpoint": "https://hermes.pyth.network/"
+  },
   "8453": {
     "type": "mainnet",
     "sdkNetwork": "base",

--- a/internal/configs/embedded/trader-backend/chain.json
+++ b/internal/configs/embedded/trader-backend/chain.json
@@ -30,6 +30,11 @@
     "sdkNetwork": "bartio",
     "priceServiceHTTPSEndpoint": "https://hermes.pyth.network/"
   },
+  "80094": {
+    "type": "mainnet",
+    "sdkNetwork": "bera",
+    "priceServiceHTTPSEndpoint": "https://hermes.pyth.network/"
+  },
   "196": {
     "type": "mainnet",
     "sdkNetwork": "xlayer",

--- a/internal/configs/embedded/trader-backend/live.referralSettings.json
+++ b/internal/configs/embedded/trader-backend/live.referralSettings.json
@@ -102,6 +102,23 @@
     "brokerId": "broker1"
   },
   {
+    "chainId": 80094,
+    "paymentMaxLookBackDays": 14,
+    "paymentScheduleCron": "0 08 * * 2",
+    "tokenX": {
+      "address": "0xDc28023CCdfbE553643c41A335a4F555Edf937Df",
+      "decimals": 18
+    },
+    "referrerCutPercentForTokenXHolding": [
+      [0.2, 0],
+      [1.5, 100],
+      [2.5, 1000],
+      [3.75, 10000]
+    ],
+    "brokerPayoutAddr": "0xdef43CF2Dd024abc5447C1Dcdc2fE3FE58547b84",
+    "brokerId": "broker1"
+  },
+  {
     "chainId": 196,
     "paymentMaxLookBackDays": 14,
     "paymentScheduleCron": "0 08 * * 2",

--- a/internal/configs/embedded/trader-backend/live.referralSettings.json
+++ b/internal/configs/embedded/trader-backend/live.referralSettings.json
@@ -1,39 +1,5 @@
 [
   {
-    "chainId": 195,
-    "paymentMaxLookBackDays": 14,
-    "paymentScheduleCron": "0 14 * * 2",
-    "tokenX": {
-      "address": "0x2444BdA650cAAe90219aa15FEd3D195a6117579F",
-      "decimals": 18
-    },
-    "referrerCutPercentForTokenXHolding": [
-      [0.2, 0],
-      [1.5, 100],
-      [2.5, 1000],
-      [3.75, 10000]
-    ],
-    "brokerPayoutAddr": "0xdef43CF2Dd024abc5447C1Dcdc2fE3FE58547b84",
-    "brokerId": "broker1"
-  },
-  {
-    "chainId": 1101,
-    "paymentMaxLookBackDays": 14,
-    "paymentScheduleCron": "0 08 * * 2",
-    "tokenX": {
-      "address": "0xDc28023CCdfbE553643c41A335a4F555Edf937Df",
-      "decimals": 18
-    },
-    "referrerCutPercentForTokenXHolding": [
-      [0.2, 0],
-      [1.5, 100],
-      [2.5, 1000],
-      [3.75, 10000]
-    ],
-    "brokerPayoutAddr": "0xdef43CF2Dd024abc5447C1Dcdc2fE3FE58547b84",
-    "brokerId": "broker1"
-  },
-  {
     "chainId": 421614,
     "paymentMaxLookBackDays": 14,
     "paymentScheduleCron": "0 08 * * 2",
@@ -42,10 +8,22 @@
       "decimals": 18
     },
     "referrerCutPercentForTokenXHolding": [
-      [0.2, 0],
-      [1.5, 100],
-      [2.5, 1000],
-      [3.75, 10000]
+      [
+        0.2,
+        0
+      ],
+      [
+        1.5,
+        100
+      ],
+      [
+        2.5,
+        1000
+      ],
+      [
+        3.75,
+        10000
+      ]
     ],
     "brokerPayoutAddr": "0xdef43CF2Dd024abc5447C1Dcdc2fE3FE58547b84",
     "brokerId": "broker1"
@@ -59,16 +37,28 @@
       "decimals": 18
     },
     "referrerCutPercentForTokenXHolding": [
-      [0.2, 0],
-      [1.5, 100],
-      [2.5, 1000],
-      [3.75, 10000]
+      [
+        0.2,
+        0
+      ],
+      [
+        1.5,
+        100
+      ],
+      [
+        2.5,
+        1000
+      ],
+      [
+        3.75,
+        10000
+      ]
     ],
     "brokerPayoutAddr": "0xdef43CF2Dd024abc5447C1Dcdc2fE3FE58547b84",
     "brokerId": "broker1"
   },
   {
-    "chainId": 2442,
+    "chainId": 84532,
     "paymentMaxLookBackDays": 14,
     "paymentScheduleCron": "0 08 * * 2",
     "tokenX": {
@@ -76,61 +66,22 @@
       "decimals": 18
     },
     "referrerCutPercentForTokenXHolding": [
-      [0.2, 0],
-      [1.5, 100],
-      [2.5, 1000],
-      [3.75, 10000]
-    ],
-    "brokerPayoutAddr": "0xdef43CF2Dd024abc5447C1Dcdc2fE3FE58547b84",
-    "brokerId": "broker1"
-  },
-  {
-    "chainId": 80084,
-    "paymentMaxLookBackDays": 14,
-    "paymentScheduleCron": "0 08 * * 2",
-    "tokenX": {
-      "address": "0x2f8cDc8383ba7f60f005e8eA8214796523da7Faa",
-      "decimals": 18
-    },
-    "referrerCutPercentForTokenXHolding": [
-      [0.2, 0],
-      [1.5, 100],
-      [2.5, 1000],
-      [3.75, 10000]
-    ],
-    "brokerPayoutAddr": "0xdef43CF2Dd024abc5447C1Dcdc2fE3FE58547b84",
-    "brokerId": "broker1"
-  },
-  {
-    "chainId": 80094,
-    "paymentMaxLookBackDays": 14,
-    "paymentScheduleCron": "0 08 * * 2",
-    "tokenX": {
-      "address": "0xDc28023CCdfbE553643c41A335a4F555Edf937Df",
-      "decimals": 18
-    },
-    "referrerCutPercentForTokenXHolding": [
-      [0.2, 0],
-      [1.5, 100],
-      [2.5, 1000],
-      [3.75, 10000]
-    ],
-    "brokerPayoutAddr": "0xdef43CF2Dd024abc5447C1Dcdc2fE3FE58547b84",
-    "brokerId": "broker1"
-  },
-  {
-    "chainId": 196,
-    "paymentMaxLookBackDays": 14,
-    "paymentScheduleCron": "0 08 * * 2",
-    "tokenX": {
-      "address": "0xDc28023CCdfbE553643c41A335a4F555Edf937Df",
-      "decimals": 18
-    },
-    "referrerCutPercentForTokenXHolding": [
-      [0.2, 0],
-      [1.5, 100],
-      [2.5, 1000],
-      [3.75, 10000]
+      [
+        0.2,
+        0
+      ],
+      [
+        1.5,
+        100
+      ],
+      [
+        2.5,
+        1000
+      ],
+      [
+        3.75,
+        10000
+      ]
     ],
     "brokerPayoutAddr": "0xdef43CF2Dd024abc5447C1Dcdc2fE3FE58547b84",
     "brokerId": "broker1"
@@ -144,10 +95,22 @@
       "decimals": 18
     },
     "referrerCutPercentForTokenXHolding": [
-      [0.2, 0],
-      [1.5, 100],
-      [2.5, 1000],
-      [3.75, 10000]
+      [
+        0.2,
+        0
+      ],
+      [
+        1.5,
+        100
+      ],
+      [
+        2.5,
+        1000
+      ],
+      [
+        3.75,
+        10000
+      ]
     ],
     "brokerPayoutAddr": "0xdef43CF2Dd024abc5447C1Dcdc2fE3FE58547b84",
     "brokerId": "broker1"

--- a/internal/configs/embedded/trader-backend/rpc.history.json
+++ b/internal/configs/embedded/trader-backend/rpc.history.json
@@ -1,32 +1,52 @@
 [
   {
     "chainId": 195,
-    "HTTP": ["https://testrpc.xlayer.tech", "https://xlayertestrpc.okx.com/"],
-    "WS": ["wss://xlayertestws.okx.com", "wss://testws.xlayer.tech"]
+    "HTTP": [
+      "https://testrpc.xlayer.tech",
+      "https://xlayertestrpc.okx.com/"
+    ],
+    "WS": [
+      "wss://xlayertestws.okx.com",
+      "wss://testws.xlayer.tech"
+    ]
   },
   {
     "chainId": 196,
-    "HTTP": ["https://xlayerrpc.okx.com", "https://rpc.xlayer.tech"],
-    "WS": ["wss://xlayerws.okx.com", "wss://ws.xlayer.tech"]
+    "HTTP": [
+      "https://xlayerrpc.okx.com",
+      "https://rpc.xlayer.tech"
+    ],
+    "WS": [
+      "wss://xlayerws.okx.com",
+      "wss://ws.xlayer.tech"
+    ]
   },
   {
     "chainId": 1101,
-    "HTTP": ["https://zkevm-rpc.com"],
+    "HTTP": [
+      "https://zkevm-rpc.com"
+    ],
     "WS": []
   },
   {
     "chainId": 2442,
-    "HTTP": ["https://rpc.cardona.zkevm-rpc.com"],
+    "HTTP": [
+      "https://rpc.cardona.zkevm-rpc.com"
+    ],
     "WS": []
   },
   {
     "chainId": 80084,
-    "HTTP": ["https://bartio.rpc.berachain.com/"],
+    "HTTP": [
+      "https://bartio.rpc.berachain.com/"
+    ],
     "WS": []
   },
   {
     "chainId": 80094,
-    "HTTP": ["https://rpc.berachain.com/"],
+    "HTTP": [
+      "https://rpc.berachain.com/"
+    ],
     "WS": []
   },
   {
@@ -39,12 +59,23 @@
   },
   {
     "chainId": 42161,
-    "HTTP": ["https://arb1.arbitrum.io/rpc"],
+    "HTTP": [
+      "https://arb1.arbitrum.io/rpc"
+    ],
+    "WS": []
+  },
+  {
+    "chainId": 84532,
+    "HTTP": [
+      "https://sepolia.base.org"
+    ],
     "WS": []
   },
   {
     "chainId": 8453,
-    "HTTP": ["https://mainnet.base.org"],
+    "HTTP": [
+      "https://mainnet.base.org"
+    ],
     "WS": []
   }
 ]

--- a/internal/configs/embedded/trader-backend/rpc.history.json
+++ b/internal/configs/embedded/trader-backend/rpc.history.json
@@ -25,6 +25,11 @@
     "WS": []
   },
   {
+    "chainId": 80094,
+    "HTTP": ["https://rpc.berachain.com/"],
+    "WS": []
+  },
+  {
     "chainId": 421614,
     "HTTP": [
       "https://sepolia-rollup.arbitrum.io/rpc",

--- a/internal/configs/embedded/trader-backend/rpc.main.json
+++ b/internal/configs/embedded/trader-backend/rpc.main.json
@@ -1,32 +1,52 @@
 [
   {
     "chainId": 195,
-    "HTTP": ["https://testrpc.xlayer.tech", "https://xlayertestrpc.okx.com/"],
-    "WS": ["wss://xlayertestws.okx.com", "wss://testws.xlayer.tech"]
+    "HTTP": [
+      "https://testrpc.xlayer.tech",
+      "https://xlayertestrpc.okx.com/"
+    ],
+    "WS": [
+      "wss://xlayertestws.okx.com",
+      "wss://testws.xlayer.tech"
+    ]
   },
   {
     "chainId": 196,
-    "HTTP": ["https://xlayerrpc.okx.com", "https://rpc.xlayer.tech"],
-    "WS": ["wss://xlayerws.okx.com", "wss://ws.xlayer.tech"]
+    "HTTP": [
+      "https://xlayerrpc.okx.com",
+      "https://rpc.xlayer.tech"
+    ],
+    "WS": [
+      "wss://xlayerws.okx.com",
+      "wss://ws.xlayer.tech"
+    ]
   },
   {
     "chainId": 1101,
-    "HTTP": ["https://zkevm-rpc.com"],
+    "HTTP": [
+      "https://zkevm-rpc.com"
+    ],
     "WS": []
   },
   {
     "chainId": 2442,
-    "HTTP": ["https://rpc.cardona.zkevm-rpc.com"],
+    "HTTP": [
+      "https://rpc.cardona.zkevm-rpc.com"
+    ],
     "WS": []
   },
   {
     "chainId": 80084,
-    "HTTP": ["https://bartio.rpc.berachain.com/"],
+    "HTTP": [
+      "https://bartio.rpc.berachain.com/"
+    ],
     "WS": []
   },
   {
     "chainId": 80094,
-    "HTTP": ["https://rpc.berachain.com/"],
+    "HTTP": [
+      "https://rpc.berachain.com/"
+    ],
     "WS": []
   },
   {
@@ -39,12 +59,23 @@
   },
   {
     "chainId": 42161,
-    "HTTP": ["https://arb1.arbitrum.io/rpc"],
+    "HTTP": [
+      "https://arb1.arbitrum.io/rpc"
+    ],
+    "WS": []
+  },
+  {
+    "chainId": 84532,
+    "HTTP": [
+      "https://sepolia.base.org"
+    ],
     "WS": []
   },
   {
     "chainId": 8453,
-    "HTTP": ["https://mainnet.base.org"],
+    "HTTP": [
+      "https://mainnet.base.org"
+    ],
     "WS": []
   }
 ]

--- a/internal/configs/embedded/trader-backend/rpc.main.json
+++ b/internal/configs/embedded/trader-backend/rpc.main.json
@@ -25,6 +25,11 @@
     "WS": []
   },
   {
+    "chainId": 80094,
+    "HTTP": ["https://rpc.berachain.com/"],
+    "WS": []
+  },
+  {
     "chainId": 421614,
     "HTTP": [
       "https://sepolia-rollup.arbitrum.io/rpc",

--- a/internal/configs/embedded/trader-backend/rpc.referral.json
+++ b/internal/configs/embedded/trader-backend/rpc.referral.json
@@ -1,32 +1,52 @@
 [
   {
     "chainId": 195,
-    "HTTP": ["https://testrpc.xlayer.tech", "https://xlayertestrpc.okx.com/"],
-    "WS": ["wss://xlayertestws.okx.com", "wss://testws.xlayer.tech"]
+    "HTTP": [
+      "https://testrpc.xlayer.tech",
+      "https://xlayertestrpc.okx.com/"
+    ],
+    "WS": [
+      "wss://xlayertestws.okx.com",
+      "wss://testws.xlayer.tech"
+    ]
   },
   {
     "chainId": 196,
-    "HTTP": ["https://xlayerrpc.okx.com", "https://rpc.xlayer.tech"],
-    "WS": ["wss://xlayerws.okx.com", "wss://ws.xlayer.tech"]
+    "HTTP": [
+      "https://xlayerrpc.okx.com",
+      "https://rpc.xlayer.tech"
+    ],
+    "WS": [
+      "wss://xlayerws.okx.com",
+      "wss://ws.xlayer.tech"
+    ]
   },
   {
     "chainId": 1101,
-    "HTTP": ["https://zkevm-rpc.com"],
+    "HTTP": [
+      "https://zkevm-rpc.com"
+    ],
     "WS": []
   },
   {
     "chainId": 2442,
-    "HTTP": ["https://rpc.cardona.zkevm-rpc.com"],
+    "HTTP": [
+      "https://rpc.cardona.zkevm-rpc.com"
+    ],
     "WS": []
   },
   {
     "chainId": 80084,
-    "HTTP": ["https://bartio.rpc.berachain.com/"],
+    "HTTP": [
+      "https://bartio.rpc.berachain.com/"
+    ],
     "WS": []
   },
   {
     "chainId": 80094,
-    "HTTP": ["https://rpc.berachain.com/"],
+    "HTTP": [
+      "https://rpc.berachain.com/"
+    ],
     "WS": []
   },
   {
@@ -39,12 +59,23 @@
   },
   {
     "chainId": 42161,
-    "HTTP": ["https://arb1.arbitrum.io/rpc"],
+    "HTTP": [
+      "https://arb1.arbitrum.io/rpc"
+    ],
+    "WS": []
+  },
+  {
+    "chainId": 84532,
+    "HTTP": [
+      "https://sepolia.base.org"
+    ],
     "WS": []
   },
   {
     "chainId": 8453,
-    "HTTP": ["https://mainnet.base.org"],
+    "HTTP": [
+      "https://mainnet.base.org"
+    ],
     "WS": []
   }
 ]

--- a/internal/configs/embedded/trader-backend/rpc.referral.json
+++ b/internal/configs/embedded/trader-backend/rpc.referral.json
@@ -25,6 +25,11 @@
     "WS": []
   },
   {
+    "chainId": 80094,
+    "HTTP": ["https://rpc.berachain.com/"],
+    "WS": []
+  },
+  {
     "chainId": 421614,
     "HTTP": [
       "https://sepolia-rollup.arbitrum.io/rpc",

--- a/internal/configs/embedded/trader-backend/tf-aws/main.tf
+++ b/internal/configs/embedded/trader-backend/tf-aws/main.tf
@@ -25,7 +25,7 @@ data "aws_ami" "ubuntu" {
   most_recent = true
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20230608"]
+    values = ["ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20240904"]
   }
 
   filter {

--- a/internal/configs/embedded/trader-backend/tf-linode/main.tf
+++ b/internal/configs/embedded/trader-backend/tf-linode/main.tf
@@ -15,7 +15,7 @@ resource "linode_instance" "manager" {
   region          = var.region
   private_ip      = true
   label           = format("%s-%s", var.server_label_prefix, "manager")
-  image           = "linode/ubuntu22.04"
+  image           = "linode/ubuntu24.04"
   booted          = true
   authorized_keys = var.authorized_keys
 }
@@ -27,7 +27,7 @@ resource "linode_instance" "nodes" {
   region          = var.region
   private_ip      = true
   label           = format("%s-%s", var.server_label_prefix, "worker-${count.index + 1}")
-  image           = "linode/ubuntu22.04"
+  image           = "linode/ubuntu24.04"
   booted          = true
   authorized_keys = var.authorized_keys
 }
@@ -38,7 +38,7 @@ resource "linode_instance" "broker_server" {
   region          = var.region
   private_ip      = true
   label           = format("%s-%s", var.server_label_prefix, "broker-server")
-  image           = "linode/ubuntu22.04"
+  image           = "linode/ubuntu24.04"
   booted          = true
   authorized_keys = var.authorized_keys
 }


### PR DESCRIPTION
Add ubuntu 24.04 images to CLI.

Some issues: 
- ufw is not marked as breaking iptables-persistent, therefore ufw cannot be used directly anymore (applies only for linode)
-  24.04 removed systemd sshd unit symlink, only ssh is present now, therefore ssh should be reloaded instead of sshd 